### PR TITLE
Update prediction submission logic

### DIFF
--- a/pdr_backend/predictoor/main.py
+++ b/pdr_backend/predictoor/main.py
@@ -72,10 +72,6 @@ def process_block(block):
             if predicted_value is not None and predicted_confidence > 0:
                 """We have a prediction, let's submit it"""
                 stake_amount = os.getenv("STAKE_AMOUNT", 1) * predicted_confidence / 100 # TODO have a customizable function to handle this
-                if topics[address]["last_submited_epoch"] == epoch and "last_submited_stake" in topics[address]:
-                    # overwrite stake amount to previous one
-                    # smart contract does not allow modifying the stake amount
-                    stake_amount = topics[address]["last_submited_stake"]
                 print(
                     f"Contract:{predictoor_contract.contract_address} - Submiting prediction for slot:{target_time}"
                 )
@@ -83,7 +79,6 @@ def process_block(block):
                     predicted_value, stake_amount, target_time, False
                 )
                 topics[address]["last_submited_epoch"] = epoch
-                topics[address]["last_submited_stake"] = stake_amount
             else:
                 print(
                     f"We do not submit, prediction function returned ({predicted_value}, {predicted_confidence})"


### PR DESCRIPTION
Fixes #26

Changes proposed in this PR:

- Predictoor is asked to make predictions for all blocks within the minute before the epoch closes until the epoch close time.
- Allow modification of stake amount between predictions