### PR TITLE
Towards #13: rename query_predictContracts -> query_feed_contracts

### DIFF
--- a/pdr_backend/dfbuyer/main.py
+++ b/pdr_backend/dfbuyer/main.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 from pdr_backend.dfbuyer.subgraph import get_consume_so_far
 from pdr_backend.models.predictoor_contract import PredictoorContract
 from pdr_backend.util.env import getenv_or_exit
-from pdr_backend.util.subgraph import query_predictContracts
+from pdr_backend.util.subgraph import query_feed_contracts
 from pdr_backend.util.web3_config import Web3Config
 
 rpc_url = getenv_or_exit("RPC_URL")
@@ -65,7 +65,7 @@ def process_block(block):
     """Process each contract and see if we need to submit"""
     global topics
     if not topics:
-        topics = query_predictContracts(
+        topics = query_feed_contracts(
             subgraph_url,
             pair_filters,
             timeframe_filter,

--- a/pdr_backend/models/base_config.py
+++ b/pdr_backend/models/base_config.py
@@ -5,7 +5,7 @@ from enforce_typing import enforce_types
 from pdr_backend.models.predictoor_contract import PredictoorContract
 from pdr_backend.models.slot import Slot
 from pdr_backend.util.env import getenv_or_exit, parse_filters
-from pdr_backend.util.subgraph import get_pending_slots, query_predictContracts
+from pdr_backend.util.subgraph import get_pending_slots, query_feed_contracts
 from pdr_backend.util.web3_config import Web3Config
 
 
@@ -42,7 +42,7 @@ class BaseConfig:
 
     def get_feeds(self) -> Dict[str, dict]:
         """Return dict of [feed_addr] : {"name":.., "pair":.., ..}"""
-        feeds_dict = query_predictContracts(
+        feeds_dict = query_feed_contracts(
             self.subgraph_url,
             self.pair_filters,
             self.timeframe_filter,

--- a/pdr_backend/models/test/test_base_config.py
+++ b/pdr_backend/models/test/test_base_config.py
@@ -58,15 +58,15 @@ def test_base_config_feeds_contracts(monkeypatch):
     c = BaseConfig()
 
     # test get_feeds()
-    def _mock_query_predictContracts(
+    def _mock_query_feed_contracts(
         *args, **kwargs
     ):  # pylint: disable=unused-argument
         feeds_dict = {ADDR: "a mock_contract"}
         return feeds_dict
 
     with patch(
-        "pdr_backend.models.base_config.query_predictContracts",
-        _mock_query_predictContracts,
+        "pdr_backend.models.base_config.query_feed_contracts",
+        _mock_query_feed_contracts,
     ):
         feeds = c.get_feeds()
     feed_addrs = list(feeds.keys())

--- a/pdr_backend/models/test/test_base_config.py
+++ b/pdr_backend/models/test/test_base_config.py
@@ -58,9 +58,7 @@ def test_base_config_feeds_contracts(monkeypatch):
     c = BaseConfig()
 
     # test get_feeds()
-    def _mock_query_feed_contracts(
-        *args, **kwargs
-    ):  # pylint: disable=unused-argument
+    def _mock_query_feed_contracts(*args, **kwargs):  # pylint: disable=unused-argument
         feeds_dict = {ADDR: "a mock_contract"}
         return feeds_dict
 

--- a/pdr_backend/predictoor/approach1/main.py
+++ b/pdr_backend/predictoor/approach1/main.py
@@ -6,7 +6,7 @@ from typing import Dict
 from pdr_backend.models.predictoor_contract import PredictoorContract
 from pdr_backend.predictoor.approach1.predict import predict_function
 from pdr_backend.util.env import getenv_or_exit
-from pdr_backend.util.subgraph import query_predictContracts
+from pdr_backend.util.subgraph import query_feed_contracts
 from pdr_backend.util.web3_config import Web3Config
 
 last_block_time = 0
@@ -32,7 +32,7 @@ def process_block(block):
     """
     global topics
     if not topics:
-        topics = query_predictContracts(
+        topics = query_feed_contracts(
             subgraph_url,
             pair_filters,
             timeframe_filter,

--- a/pdr_backend/predictoor/approach2/main.py
+++ b/pdr_backend/predictoor/approach2/main.py
@@ -12,7 +12,7 @@ import pandas as pd
 from pdr_backend.models.predictoor_contract import PredictoorContract
 from pdr_backend.predictoor.approach2.predict import predict_function
 from pdr_backend.util.env import getenv_or_exit
-from pdr_backend.util.subgraph import query_predictContracts
+from pdr_backend.util.subgraph import query_feed_contracts
 from pdr_backend.util.web3_config import Web3Config
 
 # set envvar model MODELDIR before calling main.py. eg ~/code/pdr-model-simple/
@@ -59,7 +59,7 @@ def process_block(block, model, main_pd):
     """
     global topics
     if not topics:
-        topics = query_predictContracts(
+        topics = query_feed_contracts(
             subgraph_url,
             pair_filters,
             timeframe_filter,

--- a/pdr_backend/trader/main.py
+++ b/pdr_backend/trader/main.py
@@ -5,7 +5,7 @@ from typing import Dict
 from pdr_backend.models.predictoor_contract import PredictoorContract
 from pdr_backend.trader.trade import trade
 from pdr_backend.util.env import getenv_or_exit
-from pdr_backend.util.subgraph import query_predictContracts
+from pdr_backend.util.subgraph import query_feed_contracts
 from pdr_backend.util.web3_config import Web3Config
 
 rpc_url = getenv_or_exit("RPC_URL")
@@ -28,7 +28,7 @@ def process_block(block):
     """Process each contract and see if we need to submit"""
     global topics
     if not topics:
-        topics = query_predictContracts(
+        topics = query_feed_contracts(
             subgraph_url,
             pair_filters,
             timeframe_filter,

--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -167,7 +167,7 @@ def query_pending_payouts(subgraph_url: str, addr: str) -> List[int]:
 
 
 @enforce_types
-def query_predictContracts(  # pylint: disable=too-many-statements
+def query_feed_contracts(  # pylint: disable=too-many-statements
     subgraph_url: str,
     pairs_string: Optional[str] = None,
     timeframes_string: Optional[str] = None,

--- a/pdr_backend/util/test/test_subgraph.py
+++ b/pdr_backend/util/test/test_subgraph.py
@@ -11,7 +11,7 @@ from pdr_backend.util.subgraph import (
     value_from_725,
     info_from_725,
     query_subgraph,
-    query_predictContracts,
+    query_feed_contracts,
     get_pending_slots,
 )
 
@@ -90,7 +90,7 @@ def test_query_subgraph_badpath(monkeypatch):
 def test_get_contracts_emptychain(monkeypatch):
     contract_list = []
     monkeypatch.setattr(requests, "post", MockPost(contract_list))
-    contracts = query_predictContracts(subgraph_url="foo")
+    contracts = query_feed_contracts(subgraph_url="foo")
     assert contracts == {}
 
 
@@ -122,7 +122,7 @@ def test_get_contracts_fullchain(monkeypatch):
     }
     contract_list = [contract1]
     monkeypatch.setattr(requests, "post", MockPost(contract_list))
-    contracts = query_predictContracts(subgraph_url="foo")
+    contracts = query_feed_contracts(subgraph_url="foo")
     assert contracts == {
         "contract1": {
             "name": "ether",
@@ -193,7 +193,7 @@ def test_filter(monkeypatch, expect_result, pairs, timeframes, sources, owners):
     contract_list = [contract1]
 
     monkeypatch.setattr(requests, "post", MockPost(contract_list))
-    contracts = query_predictContracts("foo", pairs, timeframes, sources, owners)
+    contracts = query_feed_contracts("foo", pairs, timeframes, sources, owners)
 
     assert bool(contracts) == bool(expect_result)
 


### PR DESCRIPTION
Towards #13