### PR TITLE
Fix #122: When running publisher, get errors in get_feeds()

### DIFF
--- a/READMEs/predictoor.md
+++ b/READMEs/predictoor.md
@@ -94,7 +94,7 @@ export MODELDIR=$(pwd)/pdr-model-simple/
 pip install scikit-learn ta
 
 #run model-powered predictoor agent
-python pdr_backend/predictoor/main.py 1
+python pdr_backend/predictoor/main.py 2
 ```
 
 ## Remote Testnet Usage

--- a/READMEs/predictoor.md
+++ b/READMEs/predictoor.md
@@ -94,7 +94,7 @@ export MODELDIR=$(pwd)/pdr-model-simple/
 pip install scikit-learn ta
 
 #run model-powered predictoor agent
-python pdr_backend/predictoor/main.py 2
+python pdr_backend/predictoor/main.py 1
 ```
 
 ## Remote Testnet Usage

--- a/pdr_backend/models/base_config.py
+++ b/pdr_backend/models/base_config.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from enforce_typing import enforce_types
 

--- a/pdr_backend/models/base_config.py
+++ b/pdr_backend/models/base_config.py
@@ -19,11 +19,11 @@ class BaseConfig(StrMixin):
         self.subgraph_url: str = getenv_or_exit("SUBGRAPH_URL")  # type: ignore
         self.private_key: str = getenv_or_exit("PRIVATE_KEY")  # type: ignore
 
-        filters = parse_filters()
-        self.pair_filters: Optional[List[str]] = filters[0]  # type: ignore
-        self.timeframe_filter: Optional[List[str]] = filters[1]  # type: ignore
-        self.source_filter: Optional[List[str]] = filters[2]  # type: ignore
-        self.owner_addresses: Optional[List[str]] = filters[3]  # type: ignore
+        (f0, f1, f2, f3) = parse_filters()
+        self.pair_filters: [List[str]] = f0
+        self.timeframe_filter: [List[str]] = f1
+        self.source_filter: [List[str]] = f2
+        self.owner_addresses: [List[str]] = f3
 
         self.web3_config = Web3Config(self.rpc_url, self.private_key)
 
@@ -41,10 +41,10 @@ class BaseConfig(StrMixin):
         """Return dict of [feed_addr] : {"name":.., "pair":.., ..}"""
         feed_dicts = query_feed_contracts(
             self.subgraph_url,
-            self.pair_filters,
-            self.timeframe_filter,
-            self.source_filter,
-            self.owner_addresses,
+            ",".join(self.pair_filters),
+            ",".join(self.timeframe_filter),
+            ",".join(self.source_filter),
+            ",".join(self.owner_addresses),
         )
         feeds = {addr: dictToFeed(feed_dict) for addr, feed_dict in feed_dicts.items()}
         return feeds

--- a/pdr_backend/models/feed.py
+++ b/pdr_backend/models/feed.py
@@ -41,7 +41,7 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
 
     @enforce_types
     def _splitpair(self) -> List[str]:
-        pair = self.pair.replace("/","-")
+        pair = self.pair.replace("/", "-")
         return pair.split("-")
 
     @enforce_types

--- a/pdr_backend/models/feed.py
+++ b/pdr_backend/models/feed.py
@@ -14,6 +14,7 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
         symbol: str,
         seconds_per_epoch: int,
         seconds_per_subscription: int,
+        trueval_submit_timeout: int,
         owner: str,
         pair: str,
         timeframe: str,
@@ -24,6 +25,7 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
         self.symbol = symbol
         self.seconds_per_epoch = seconds_per_epoch
         self.seconds_per_subscription = seconds_per_subscription
+        self.trueval_submit_timeout = trueval_submit_timeout
         self.owner = owner
         self.pair = pair
         self.timeframe = timeframe
@@ -72,6 +74,7 @@ def dictToFeed(feed_dict: Dict[str, Any]):
         symbol=d["symbol"],
         seconds_per_epoch=int(d["seconds_per_epoch"]),
         seconds_per_subscription=int(d["seconds_per_subscription"]),
+        trueval_submit_timeout=int(d["trueval_submit_timeout"]),
         owner=d["owner"],
         pair=d["pair"],
         timeframe=d["timeframe"],

--- a/pdr_backend/models/feed.py
+++ b/pdr_backend/models/feed.py
@@ -14,7 +14,6 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
         symbol: str,
         seconds_per_epoch: int,
         seconds_per_subscription: int,
-        trueval_submit_timeout: int,
         owner: str,
         pair: str,
         timeframe: str,
@@ -25,7 +24,6 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
         self.symbol = symbol
         self.seconds_per_epoch = seconds_per_epoch
         self.seconds_per_subscription = seconds_per_subscription
-        self.trueval_submit_timeout = trueval_submit_timeout
         self.owner = owner
         self.pair = pair
         self.timeframe = timeframe
@@ -65,9 +63,8 @@ def dictToFeed(feed_dict: Dict[str, Any]):
         name=d["name"],
         address=d["address"],
         symbol=d["symbol"],
-        seconds_per_epoch=d["seconds_per_epoch"],
-        seconds_per_subscription=d["seconds_per_subscription"],
-        trueval_submit_timeout=d["trueval_submit_timeout"],
+        seconds_per_epoch=int(d["seconds_per_epoch"]),
+        seconds_per_subscription=int(d["seconds_per_subscription"]),
         owner=d["owner"],
         pair=d["pair"],
         timeframe=d["timeframe"],

--- a/pdr_backend/models/feed.py
+++ b/pdr_backend/models/feed.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from enforce_typing import enforce_types
 
@@ -30,18 +30,25 @@ class Feed(StrMixin):  # pylint: disable=too-many-instance-attributes
         self.source = source
 
     @property
-    def quote(self):
-        return self.pair.split("-")[1]
+    def base(self):
+        return self._splitpair()[0]
 
     @property
-    def base(self):
-        return self.pair.split("-")[0]
+    def quote(self):
+        return self._splitpair()[1]
 
+    @enforce_types
+    def _splitpair(self) -> List[str]:
+        pair = self.pair.replace("/","-")
+        return pair.split("-")
+
+    @enforce_types
     def shortstr(self) -> str:
         return (
             f"[Feed {self.address[:7]} {self.pair}" f"|{self.source}|{self.timeframe}]"
         )
 
+    @enforce_types
     def __str__(self) -> str:
         return self.shortstr()
 

--- a/pdr_backend/models/test/test_base_config.py
+++ b/pdr_backend/models/test/test_base_config.py
@@ -44,10 +44,10 @@ def test_base_config_with_filters(monkeypatch):
 def test_base_config_no_filters(monkeypatch):
     _setenvs(monkeypatch, have_filters=False)
     c = BaseConfig()
-    assert c.pair_filters is None
-    assert c.timeframe_filter is None
-    assert c.source_filter is None
-    assert c.owner_addresses is None
+    assert c.pair_filters == []
+    assert c.timeframe_filter == []
+    assert c.source_filter == []
+    assert c.owner_addresses == []
 
 
 @enforce_types

--- a/pdr_backend/models/test/test_feed.py
+++ b/pdr_backend/models/test/test_feed.py
@@ -4,14 +4,13 @@ from pdr_backend.models.feed import dictToFeed, Feed
 
 
 @enforce_types
-def test_feed1():
+def test_feed__construct_directly():
     feed = Feed(
         "Contract Name",
         "0x12345",
-        "test",
+        "SYM:TEST",
         300,
         60,
-        15,
         "0xowner",
         "BTC-ETH",
         "1h",
@@ -23,7 +22,6 @@ def test_feed1():
     assert feed.symbol == "test"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
-    assert feed.trueval_submit_timeout == 15
     assert feed.owner == "0xowner"
     assert feed.pair == "BTC-ETH"
     assert feed.timeframe == "1h"
@@ -33,14 +31,13 @@ def test_feed1():
 
 
 @enforce_types
-def test_feed2():
+def test_feed__construct_via_dictToFeed():
     feed_dict = {
         "name": "Contract Name",
         "address": "0x12345",
         "symbol": "test",
         "seconds_per_epoch": 300,
         "seconds_per_subscription": 60,
-        "trueval_submit_timeout": 15,
         "owner": "0xowner",
         "pair": "BTC-ETH",
         "timeframe": "1h",
@@ -54,7 +51,6 @@ def test_feed2():
     assert feed.symbol == "test"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
-    assert feed.trueval_submit_timeout == 15
     assert feed.owner == "0xowner"
     assert feed.pair == "BTC-ETH"
     assert feed.timeframe == "1h"

--- a/pdr_backend/models/test/test_feed.py
+++ b/pdr_backend/models/test/test_feed.py
@@ -11,6 +11,7 @@ def test_feed__construct_directly():
         "SYM:TEST",
         300,
         60,
+        15,
         "0xowner",
         "BTC-USDT",
         "1h",
@@ -22,6 +23,7 @@ def test_feed__construct_directly():
     assert feed.symbol == "SYM:TEST"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
+    assert feed.trueval_submit_timeout == 15
     assert feed.owner == "0xowner"
     assert feed.pair == "BTC-USDT"
     assert feed.timeframe == "1h"
@@ -36,8 +38,9 @@ def test_feed__construct_via_dictToFeed():
         "name": "Contract Name",
         "address": "0x12345",
         "symbol": "SYM:TEST",
-        "seconds_per_epoch": 300,
-        "seconds_per_subscription": 60,
+        "seconds_per_epoch": "300",
+        "seconds_per_subscription": "60",
+        "trueval_submit_timeout": "15",
         "owner": "0xowner",
         "pair": "BTC-USDT",
         "timeframe": "1h",
@@ -51,6 +54,7 @@ def test_feed__construct_via_dictToFeed():
     assert feed.symbol == "SYM:TEST"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
+    assert feed.trueval_submit_timeout == 15
     assert feed.owner == "0xowner"
     assert feed.pair == "BTC-USDT"
     assert feed.timeframe == "1h"
@@ -63,3 +67,14 @@ def test_feed__construct_via_dictToFeed():
     feed = dictToFeed(feed_dict)
     assert feed.base == "BTC"
     assert feed.quote == "USDT"
+
+    # test where ints are int, not str (should work for either)
+    feed_dict.update({
+        "seconds_per_epoch": 301,
+        "seconds_per_subscription": 61,
+        "trueval_submit_timeout": 16,
+    })
+    feed = dictToFeed(feed_dict)
+    assert feed.seconds_per_epoch == 301
+    assert feed.seconds_per_subscription == 61
+    assert feed.trueval_submit_timeout == 16

--- a/pdr_backend/models/test/test_feed.py
+++ b/pdr_backend/models/test/test_feed.py
@@ -69,11 +69,13 @@ def test_feed__construct_via_dictToFeed():
     assert feed.quote == "USDT"
 
     # test where ints are int, not str (should work for either)
-    feed_dict.update({
-        "seconds_per_epoch": 301,
-        "seconds_per_subscription": 61,
-        "trueval_submit_timeout": 16,
-    })
+    feed_dict.update(
+        {
+            "seconds_per_epoch": 301,
+            "seconds_per_subscription": 61,
+            "trueval_submit_timeout": 16,
+        }
+    )
     feed = dictToFeed(feed_dict)
     assert feed.seconds_per_epoch == 301
     assert feed.seconds_per_subscription == 61

--- a/pdr_backend/models/test/test_feed.py
+++ b/pdr_backend/models/test/test_feed.py
@@ -12,21 +12,21 @@ def test_feed__construct_directly():
         300,
         60,
         "0xowner",
-        "BTC-ETH",
+        "BTC-USDT",
         "1h",
         "binance",
     )
 
     assert feed.name == "Contract Name"
     assert feed.address == "0x12345"
-    assert feed.symbol == "test"
+    assert feed.symbol == "SYM:TEST"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
     assert feed.owner == "0xowner"
-    assert feed.pair == "BTC-ETH"
+    assert feed.pair == "BTC-USDT"
     assert feed.timeframe == "1h"
     assert feed.source == "binance"
-    assert feed.quote == "ETH"
+    assert feed.quote == "USDT"
     assert feed.base == "BTC"
 
 
@@ -35,11 +35,11 @@ def test_feed__construct_via_dictToFeed():
     feed_dict = {
         "name": "Contract Name",
         "address": "0x12345",
-        "symbol": "test",
+        "symbol": "SYM:TEST",
         "seconds_per_epoch": 300,
         "seconds_per_subscription": 60,
         "owner": "0xowner",
-        "pair": "BTC-ETH",
+        "pair": "BTC-USDT",
         "timeframe": "1h",
         "source": "binance",
     }
@@ -48,12 +48,18 @@ def test_feed__construct_via_dictToFeed():
 
     assert feed.name == "Contract Name"
     assert feed.address == "0x12345"
-    assert feed.symbol == "test"
+    assert feed.symbol == "SYM:TEST"
     assert feed.seconds_per_epoch == 300
     assert feed.seconds_per_subscription == 60
     assert feed.owner == "0xowner"
-    assert feed.pair == "BTC-ETH"
+    assert feed.pair == "BTC-USDT"
     assert feed.timeframe == "1h"
     assert feed.source == "binance"
-    assert feed.quote == "ETH"
     assert feed.base == "BTC"
+    assert feed.quote == "USDT"
+
+    # test pair with "/" (versus "-")
+    feed_dict["pair"] = "BTC/USDT"
+    feed = dictToFeed(feed_dict)
+    assert feed.base == "BTC"
+    assert feed.quote == "USDT"

--- a/pdr_backend/trueval/test/test_trueval_config.py
+++ b/pdr_backend/trueval/test/test_trueval_config.py
@@ -11,8 +11,8 @@ def test_trueval_config():
     assert config.sleep_time == int(os.getenv("SLEEP_TIME", "30"))
     assert config.batch_size == int(os.getenv("BATCH_SIZE", "30"))
 
-    filters = parse_filters()
-    assert config.pair_filters == filters[0]
-    assert config.timeframe_filter == filters[1]
-    assert config.source_filter == filters[2]
-    assert config.owner_addresses == filters[3]
+    (f0, f1, f2, f3) = parse_filters()
+    assert config.pair_filters == f0
+    assert config.timeframe_filter == f1
+    assert config.source_filter == f2
+    assert config.owner_addresses == f3

--- a/pdr_backend/util/env.py
+++ b/pdr_backend/util/env.py
@@ -1,6 +1,6 @@
 from os import getenv
 import sys
-from typing import List, Union
+from typing import List, Tuple, Union
 
 from enforce_typing import enforce_types
 
@@ -15,7 +15,7 @@ def getenv_or_exit(envvar_name: str) -> Union[None, str]:
 
 
 @enforce_types
-def parse_filters() -> List[Union[List[str], None]]:
+def parse_filters() -> Tuple[List[str]]:
     """
     @description
       Grabs envvar values for each of the filters (PAIR_FILTER, etc).
@@ -26,13 +26,22 @@ def parse_filters() -> List[Union[List[str], None]]:
       <nothing, but it grabs from env>
 
     @return
-      filter_values -- list with one item per filter:
-        0. parsed PAIR_FILTER -- either [pair1_str, pair2_str, ..] or None
-        1. parsed TIMEFRAME_FILTER -- ""
-        ...
+      parsed_pair_filter -- e.g. [] or ["ETH-USDT", "BTC-USDT"]
+      parsed_timeframe_filter -- e.g. ["5m"]
+      parsed_source_filter -- e.g. ["binance"]
+      parsed_owner_addrs -- e.g. ["0x123.."]
+
+    @notes
+      if envvar is None, the parsed filter is [], *not* None
     """
-    filter_names = ["PAIR_FILTER", "TIMEFRAME_FILTER", "SOURCE_FILTER", "OWNER_ADDRS"]
-    filter_values = [
-        getenv(name).split(",") if getenv(name) else None for name in filter_names  # type: ignore[union-attr] # pylint: disable=line-too-long
-    ]
-    return filter_values
+    def _parse1(envvar) -> List[str]:
+        envval = getenv(envvar)
+        if envval is None:
+            return []
+        return envval.split(",")
+    
+    return (_parse1("PAIR_FILTER"),
+            _parse1("TIMEFRAME_FILTER"),
+            _parse1("SOURCE_FILTER"),
+            _parse1("OWNER_ADDRS"),
+            )

--- a/pdr_backend/util/env.py
+++ b/pdr_backend/util/env.py
@@ -15,7 +15,7 @@ def getenv_or_exit(envvar_name: str) -> Union[None, str]:
 
 
 @enforce_types
-def parse_filters() -> Tuple[List[str]]:
+def parse_filters() -> Tuple[List[str], List[str], List[str], List[str]]:
     """
     @description
       Grabs envvar values for each of the filters (PAIR_FILTER, etc).
@@ -34,14 +34,16 @@ def parse_filters() -> Tuple[List[str]]:
     @notes
       if envvar is None, the parsed filter is [], *not* None
     """
+
     def _parse1(envvar) -> List[str]:
         envval = getenv(envvar)
         if envval is None:
             return []
         return envval.split(",")
-    
-    return (_parse1("PAIR_FILTER"),
-            _parse1("TIMEFRAME_FILTER"),
-            _parse1("SOURCE_FILTER"),
-            _parse1("OWNER_ADDRS"),
-            )
+
+    return (
+        _parse1("PAIR_FILTER"),
+        _parse1("TIMEFRAME_FILTER"),
+        _parse1("SOURCE_FILTER"),
+        _parse1("OWNER_ADDRS"),
+    )

--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -187,8 +187,8 @@ def query_feed_contracts(  # pylint: disable=too-many-statements
       owners -- E.g. filter to "0x123,0x124". If None/"", allow all
 
     @return
-      contracts -- dict of [contract_id] : contract_info
-        where contract_info is a dict with fields name, address, symbol, ..
+      feed_dicts -- dict of [contract_id] : feed_dict
+        where feed_dict is a dict with fields name, address, symbol, ..
     """
     pairs = None
     timeframes = None
@@ -269,8 +269,9 @@ def query_feed_contracts(  # pylint: disable=too-many-statements
                     "name": contract["token"]["name"],
                     "address": contract["id"],
                     "symbol": contract["token"]["symbol"],
-                    "seconds_per_epoch": contract["secondsPerEpoch"],
-                    "seconds_per_subscription": contract["secondsPerSubscription"],
+                    "seconds_per_epoch": int(contract["secondsPerEpoch"]),
+                    "seconds_per_subscription": int(contract["secondsPerSubscription"]),
+                    "trueval_submit_timeout": int(contract["truevalSubmitTimeout"]),
                     "owner": owner_id,
                     "last_submited_epoch": 0,
                 }

--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -181,10 +181,10 @@ def query_feed_contracts(  # pylint: disable=too-many-statements
 
     @arguments
       subgraph_url -- e.g.
-      pairs -- E.g. filter to "BTC/USDT,ETH/USDT". If None, allow all
-      timeframes -- E.g. filter to "5m,15m". If None, allow all
-      sources -- E.g. filter to "binance,kraken". If None, allow all
-      owners -- E.g. filter to "0x123,0x124". If None, allow all
+      pairs -- E.g. filter to "BTC/USDT,ETH/USDT". If None/"", allow all
+      timeframes -- E.g. filter to "5m,15m". If None/"", allow all
+      sources -- E.g. filter to "binance,kraken". If None/"", allow all
+      owners -- E.g. filter to "0x123,0x124". If None/"", allow all
 
     @return
       contracts -- dict of [contract_id] : contract_info
@@ -195,13 +195,13 @@ def query_feed_contracts(  # pylint: disable=too-many-statements
     sources = None
     owners = None
 
-    if pairs_string is not None:
+    if pairs_string:
         pairs = pairs_string.split(",")
-    if timeframes_string is not None:
+    if timeframes_string:
         timeframes = timeframes_string.split(",")
-    if sources_string is not None:
+    if sources_string:
         sources = sources_string.split(",")
-    if owners_string is not None:
+    if owners_string:
         owners = owners_string.lower().split(",")
 
     chunk_size = 1000  # max for subgraph = 1000

--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -271,6 +271,7 @@ def query_feed_contracts(  # pylint: disable=too-many-statements
                     "symbol": contract["token"]["symbol"],
                     "seconds_per_epoch": contract["secondsPerEpoch"],
                     "seconds_per_subscription": contract["secondsPerSubscription"],
+                    "owner": owner_id,
                     "last_submited_epoch": 0,
                 }
                 feed_dict.update(info)

--- a/pdr_backend/util/test/test_env.py
+++ b/pdr_backend/util/test/test_env.py
@@ -31,11 +31,11 @@ def test_parse_filters():
     with patch("pdr_backend.util.env.getenv", mock_getenv):
         result = parse_filters()
 
-    expected = [
+    expected = (
         ["BTC-USDT", "ETH-USDT"],  # pair
         ["1D", "1H"],  # timeframe
-        None,  # source
+        [],  # source
         ["0x1234", "0x5678"],  # owner_addrs
-    ]
+    )
 
     assert result == expected, f"Expected {expected}, but got {result}"

--- a/pdr_backend/util/test/test_subgraph.py
+++ b/pdr_backend/util/test/test_subgraph.py
@@ -160,6 +160,9 @@ def test_get_contracts_fullchain(monkeypatch):
         (True, None, None, None, "owner1"),
         (False, None, None, None, "owner2"),
         (True, None, None, None, "owner1,owner2"),
+        (True, None, None, None, ""),
+        (True, "", "", "", ""),
+        (True, None, None, "", "owner1,owner2"),
     ],
 )
 def test_filter(monkeypatch, expect_result, pairs, timeframes, sources, owners):


### PR DESCRIPTION
Fixes #122

Changes proposed in this PR:

- bug fix: Make subgraph.py query feeds able to handle filters with value '', in addition to value None
- add robustness: env.py::parse_filters() now returns a tuple of list[str], not a list of list[str]|None
- bug fix: get_feeds() call to query_feed_contracts guarantees to pass in a str by concatenating lists
- bug fix: subgraph.py:query_feed_contracts() wasn't adding 'owner' to feed dict, fixed it
- bug fix: models/feed.py wasn't converting from str to int as needed. Fixed it
- bug fix: trueval_submit_timeout shouldn't be in feed_dict or Feed. Removed it. But ensured that trueval agent still saw it
- bug fix: feed.py::Feed property methods base() and quote() could only handle eg BTC-USDT but not BTC/USDT. Fixed it.