### PR TITLE
Fix #204: Make predictoor payout module rock solid

### DIFF
--- a/pdr_backend/predictoor/payout.py
+++ b/pdr_backend/predictoor/payout.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import Any, List
 from enforce_typing import enforce_types
 from pdr_backend.models.base_config import BaseConfig
@@ -18,21 +19,39 @@ def request_payout_batches(
 ):
     batches = batchify(timestamps, batch_size)
     for batch in batches:
-        predictoor_contract.payout_multiple(batch, True)
-        print(".", end="", flush=True)
+        retries = 0
+        success = False
+
+        while retries < 5 and not success:
+            try:
+                predictoor_contract.payout_multiple(batch, True)
+                print(".", end="", flush=True)
+                success = True
+            except (
+                Exception
+            ) as e:  # capture and handle the specific exception that indicates a failure
+                retries += 1
+                print(f"Error: {e}. Retrying... {retries}/5", flush=True)
+                time.sleep(1)
+
+        if not success:
+            print("\nFailed after 5 attempts. Moving to next batch.", flush=True)
+
     print("\nBatch completed")
 
 
 def do_payout():
     config = BaseConfig()
     owner = config.web3_config.owner
-    BATCH_SIZE = int(os.getenv("BATCH_SIZE", "10"))
+    BATCH_SIZE = int(os.getenv("BATCH_SIZE", "250"))
+    print("Starting payout")
     wait_until_subgraph_syncs(config.web3_config, config.subgraph_url)
+    print("Finding pending payouts")
     pending_payouts = query_pending_payouts(config.subgraph_url, owner)
     total_timestamps = sum(len(timestamps) for timestamps in pending_payouts.values())
     print(f"Found {total_timestamps} slots")
 
     for contract_address in pending_payouts:
-        print(f"Claiming payouts for {contract_address} contract")
+        print(f"Claiming payouts for {contract_address}")
         contract = PredictoorContract(config.web3_config, contract_address)
         request_payout_batches(contract, BATCH_SIZE, pending_payouts[contract_address])

--- a/pdr_backend/predictoor/payout.py
+++ b/pdr_backend/predictoor/payout.py
@@ -27,9 +27,7 @@ def request_payout_batches(
                 predictoor_contract.payout_multiple(batch, True)
                 print(".", end="", flush=True)
                 success = True
-            except (
-                Exception
-            ) as e:  # capture and handle the specific exception that indicates a failure
+            except Exception as e:
                 retries += 1
                 print(f"Error: {e}. Retrying... {retries}/5", flush=True)
                 time.sleep(1)


### PR DESCRIPTION
Fixes #204

Changes proposed in this PR:

- Fixed get pending slots subgraph query.
- Added progress feedback dots.
- Added error handling and re-try mechanism.
- Increased default batch size to 250.

Tested against testnet:

```
python pdr_backend/predictoor/main.py payout
Starting payout
Finding pending payouts
..........
Found 8547 slots
Claiming payouts for 0x74f033c4b4d571c8f65da2c035a90871976476d0
.........
Batch completed
Claiming payouts for 0x7bb67c67c089e566d8650514fe872b1e16ed946b
.
Batch completed
Claiming payouts for 0xc2c5c790b411a835742ed0d517df68fea958058d
.
Batch completed
Claiming payouts for 0xda1e3c0ac74f2f10bb0c7635c9dc68bd3da0c95b
..........................
Batch completed
```
I ran the script a few more times before this run:
- Claimed payout for **13097** slots. **Equivalent to (~45.47 Days)**
- OCEAN balance of the predictoor has **increased from 33,455 to 50,094**.