### PR TITLE
Tune #221 - payout instructions

### DIFF
--- a/READMEs/payout.md
+++ b/READMEs/payout.md
@@ -1,0 +1,35 @@
+<!--
+Copyright 2023 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Claim Payout for Predictoor Bot
+
+This README describes how you can claim the $ based on running a predictoor bot.
+
+First, congratulations on your participation and progress in making predictions! Whether you've made accurate or erroneous predictions, it's now time to claim your earnings from correct predictions.
+
+### Steps to Request Payout
+
+#### 1. Preparation
+
+Ensure you pause or stop any ongoing prediction submissions. This is crucial as active submissions can interfere with the payout process.
+
+#### 2. Execute Payout
+
+- Running locally: Simply run the python script with the command: `python pdr_backend/predictoor/payout.py`.
+- Using Container Image: Simply execute the command: `predictoor payout`.
+
+#### 3. Completion
+
+Once the payout module concludes its operation, your balance will reflect the updated amount.
+
+#### 4. Verification
+
+It's good practice to run the payout module again. This ensures any failed blockchain calls from the previous attempt are addressed and verifies that all eligible payouts have been claimed.
+
+## FAQ
+
+- Q: how often to request?
+- A: While you can request a payout at any time, we suggest doing so periodically. The payout module processes requests in batches, handling up to 250 slots per transaction for efficiency.
+

--- a/READMEs/predictoor.md
+++ b/READMEs/predictoor.md
@@ -14,34 +14,8 @@ Start simple, layer in complexity.
 1. [Local predictoor, local network](localpredictoor-localnet.md)
 2. [Local predictoor, remote network](./localbot-remotenet.md) - on testnet
 3. [Remote predictoor, remote network](./remotebot-remotenet.md) - on testnet
-4. Repeat (2) or (3), on mainnet
-
-## Requesting payout
-
-Congratulations on your participation and progress in making predictions. Whether you've made accurate or erroneous predictions, it's now time to claim your earnings from correct predictions.
-
-### Recommended Payout Frequency
-
-While you can request a payout at any time, we suggest doing so periodically. The payout module processes requests in batches, handling up to 250 slots per transaction for efficiency.
-
-### Steps to Request Payout
-
-#### Preparation
-
-Ensure you pause or stop any ongoing prediction submissions. This is crucial as active submissions can interfere with the payout process.
-
-#### Execute Payout
-
-- Running locally: Simply run the python script with the command: `python pdr_backend/predictoor/payout.py`.
-- Using Container Image: Simply execute the command: `predictoor payout`.
-
-#### Completion
-
-Once the payout module concludes its operation, your balance will reflect the updated amount.
-
-#### Verification
-
-It's good practice to run the payout module again. This ensures any failed blockchain calls from the previous attempt are addressed and verifies that all eligible payouts have been claimed.
+4. Repeat (2) or (3), on mainnet. This will earn $.
+5. [Claim payout](./payout.md)
 
 ## Warning
 


### PR DESCRIPTION
#221 is already done. This PR moves the payout instructions from predictoor.md to a new sub-file payout.md. Why: too prominent if in predictoor.md.