### PR TITLE
add topup cron

### DIFF
--- a/.github/workflows/cron_topup.yml
+++ b/.github/workflows/cron_topup.yml
@@ -1,7 +1,6 @@
 name: Topup accounts
 
 on:
-  pull_request:
   schedule:
     - cron: "0 */6 * * *"
   

--- a/.github/workflows/cron_topup.yml
+++ b/.github/workflows/cron_topup.yml
@@ -1,0 +1,50 @@
+name: Topup accounts
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  
+jobs:
+  topup-mainnet:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v2
+  
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: "3.11"
+  
+        - name: Install Dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+        - name: Set env variables
+          run: |
+            echo "SUBGRAPH_URL=http://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph" >> $GITHUB_ENV
+            echo "RPC_URL=https://sapphire.oasis.io" >> $GITHUB_ENV
+            echo "PRIVATE_KEY==${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
+        - name: Run top-up script
+          run: python3 scripts/topup.py
+  
+  topup-testnet:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v2
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: "3.11"
+        - name: Install Dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+        - name: Set env variables
+          run: |
+            echo "SUBGRAPH_URL=http://v4.subgraph.sapphire-testnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph" >> $GITHUB_ENV
+            echo "RPC_URL=https://testnet.sapphire.oasis.dev" >> $GITHUB_ENV
+            echo "PRIVATE_KEY==${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
+        - name: Run top-up script
+          run: python3 scripts/topup.py

--- a/.github/workflows/cron_topup.yml
+++ b/.github/workflows/cron_topup.yml
@@ -24,7 +24,7 @@ jobs:
           run: |
             echo "SUBGRAPH_URL=http://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph" >> $GITHUB_ENV
             echo "RPC_URL=https://sapphire.oasis.io" >> $GITHUB_ENV
-            echo "PRIVATE_KEY==${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
+            echo "PRIVATE_KEY=${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
         - name: Run top-up script
           run: python3 scripts/topup.py
   
@@ -45,6 +45,6 @@ jobs:
           run: |
             echo "SUBGRAPH_URL=http://v4.subgraph.sapphire-testnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph" >> $GITHUB_ENV
             echo "RPC_URL=https://testnet.sapphire.oasis.dev" >> $GITHUB_ENV
-            echo "PRIVATE_KEY==${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
+            echo "PRIVATE_KEY=${{ secrets.TOPUP_SCRIPT_PK }}" >> $GITHUB_ENV
         - name: Run top-up script
           run: python3 scripts/topup.py

--- a/.github/workflows/cron_topup.yml
+++ b/.github/workflows/cron_topup.yml
@@ -1,6 +1,7 @@
 name: Topup accounts
 
 on:
+  pull_request:
   schedule:
     - cron: "0 */6 * * *"
   

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -1,3 +1,4 @@
+import time
 from addresses import get_opf_addresses
 from pdr_backend.models.base_config import BaseConfig
 from pdr_backend.models.token import Token, NativeToken
@@ -6,22 +7,28 @@ from pdr_backend.util.contract import get_address
 
 if __name__ == "__main__":
     config = BaseConfig()
-
+    failed = False  #if there is not enough balance, exit 1 so we know that script failed
     addresses = get_opf_addresses(config.web3_config.w3.eth.chain_id)
     ocean_address = get_address(config.web3_config.w3.eth.chain_id, "Ocean")
     ocean_token = Token(config.web3_config, ocean_address)
     rose = NativeToken(config.web3_config)
+
+    owner_ocean_balance=int(ocean_token.balanceOf(config.web3_config.owner))/1e18
+    owner_rose_balance=int(rose.balanceOf(config.web3_config.owner))/1e18
+    print(f"Topup address has : {owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n")
+    total_ocean=0
+    total_rose=0
     for name, value in addresses.items():
         ocean_bal_wei = ocean_token.balanceOf(value)
         rose_bal_wei = rose.balanceOf(value)
 
         ocean_bal = ocean_bal_wei / 1e18
         rose_bal = rose_bal_wei / 1e18
-
-        minimum_ocean_bal = 20
-        minimum_rose_bal = 15
-        topup_ocean_bal = 15
-        topup_rose_bal = 25
+        
+        minimum_ocean_bal = 10
+        minimum_rose_bal = 10
+        topup_ocean_bal = 10
+        topup_rose_bal = 10
 
         if name == "trueval":
             minimum_ocean_bal = 0
@@ -32,22 +39,31 @@ if __name__ == "__main__":
             topup_ocean_bal = 0
 
         # pylint: disable=line-too-long
-        print(f"{name}: OCEAN: {ocean_bal:.2f}, Native: {rose_bal:.2f}")
+        print(f"{name}: {ocean_bal:.2f} OCEAN, {rose_bal:.2f} ROSE")
         # check if we need to transfer
         if minimum_ocean_bal > 0 and ocean_bal < minimum_ocean_bal:
             print(f"\t Transfering {topup_ocean_bal} OCEAN to {value}...")
-            ocean_token.transfer(
-                value,
-                config.web3_config.w3.to_wei(topup_ocean_bal, "ether"),
-                config.web3_config.owner,
-                True,
-            )
-
+            if owner_ocean_balance>topup_ocean_bal:
+                ocean_token.transfer(
+                    value,
+                    config.web3_config.w3.to_wei(topup_ocean_bal, "ether"),
+                    config.web3_config.owner,
+                    True,
+                )
+                owner_ocean_balance=owner_ocean_balance-topup_ocean_bal
+            else:
+                failed = True
+                print("Not enough OCEAN :(")
         if minimum_rose_bal > 0 and rose_bal < minimum_rose_bal:
             print(f"\t Transfering {topup_rose_bal} ROSE to {value}...")
-            rose.transfer(
-                value,
-                config.web3_config.w3.to_wei(topup_rose_bal, "ether"),
-                config.web3_config.owner,
-                True,
-            )
+            if owner_rose_balance>topup_rose_bal:
+                rose.transfer(
+                    value,
+                    config.web3_config.w3.to_wei(topup_rose_bal, "ether"),
+                    config.web3_config.owner,
+                    True,
+                )
+                owner_rose_balance=owner_rose_balance-topup_rose_bal
+            else:
+                failed = True
+                print("Not enough ROSE :(")

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -11,7 +11,14 @@ if __name__ == "__main__":
         False  # if there is not enough balance, exit 1 so we know that script failed
     )
     addresses = get_opf_addresses(config.web3_config.w3.eth.chain_id)
-    ocean_address = get_address(config.web3_config.w3.eth.chain_id, "Ocean")
+    ocean_address = None
+    if config.web3_config.w3.eth.chain_id == 23294:  #mainnet
+        ocean_address = "0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520"
+    if config.web3_config.w3.eth.chain_id == 23295:  #testnet
+        ocean_address = "0x973e69303259B0c2543a38665122b773D28405fB"
+    if ocean_address is None:
+        print("Unknown network")
+        sys.exit(1)
     ocean_token = Token(config.web3_config, ocean_address)
     rose = NativeToken(config.web3_config)
 

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -2,7 +2,6 @@ import sys
 from addresses import get_opf_addresses
 from pdr_backend.models.base_config import BaseConfig
 from pdr_backend.models.token import Token, NativeToken
-from pdr_backend.util.contract import get_address
 
 
 if __name__ == "__main__":
@@ -12,13 +11,14 @@ if __name__ == "__main__":
     )
     addresses = get_opf_addresses(config.web3_config.w3.eth.chain_id)
     ocean_address = None
-    if config.web3_config.w3.eth.chain_id == 23294:  #mainnet
+    if config.web3_config.w3.eth.chain_id == 23294:  # mainnet
         ocean_address = "0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520"
-    if config.web3_config.w3.eth.chain_id == 23295:  #testnet
+    if config.web3_config.w3.eth.chain_id == 23295:  # testnet
         ocean_address = "0x973e69303259B0c2543a38665122b773D28405fB"
     if ocean_address is None:
         print("Unknown network")
         sys.exit(1)
+
     ocean_token = Token(config.web3_config, ocean_address)
     rose = NativeToken(config.web3_config)
 

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -1,4 +1,4 @@
-import time
+import sys
 from addresses import get_opf_addresses
 from pdr_backend.models.base_config import BaseConfig
 from pdr_backend.models.token import Token, NativeToken
@@ -7,24 +7,29 @@ from pdr_backend.util.contract import get_address
 
 if __name__ == "__main__":
     config = BaseConfig()
-    failed = False  #if there is not enough balance, exit 1 so we know that script failed
+    failed = (
+        False  # if there is not enough balance, exit 1 so we know that script failed
+    )
     addresses = get_opf_addresses(config.web3_config.w3.eth.chain_id)
     ocean_address = get_address(config.web3_config.w3.eth.chain_id, "Ocean")
     ocean_token = Token(config.web3_config, ocean_address)
     rose = NativeToken(config.web3_config)
 
-    owner_ocean_balance=int(ocean_token.balanceOf(config.web3_config.owner))/1e18
-    owner_rose_balance=int(rose.balanceOf(config.web3_config.owner))/1e18
-    print(f"Topup address ({config.web3_config.owner}) has : {owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n")
-    total_ocean=0
-    total_rose=0
+    owner_ocean_balance = int(ocean_token.balanceOf(config.web3_config.owner)) / 1e18
+    owner_rose_balance = int(rose.balanceOf(config.web3_config.owner)) / 1e18
+    print(
+        f"Topup address ({config.web3_config.owner}) has "
+        + "{owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n"
+    )
+    total_ocean = 0
+    total_rose = 0
     for name, value in addresses.items():
         ocean_bal_wei = ocean_token.balanceOf(value)
         rose_bal_wei = rose.balanceOf(value)
 
         ocean_bal = ocean_bal_wei / 1e18
         rose_bal = rose_bal_wei / 1e18
-        
+
         minimum_ocean_bal = 10
         minimum_rose_bal = 10
         topup_ocean_bal = 10
@@ -43,31 +48,31 @@ if __name__ == "__main__":
         # check if we need to transfer
         if minimum_ocean_bal > 0 and ocean_bal < minimum_ocean_bal:
             print(f"\t Transfering {topup_ocean_bal} OCEAN to {value}...")
-            if owner_ocean_balance>topup_ocean_bal:
+            if owner_ocean_balance > topup_ocean_bal:
                 ocean_token.transfer(
                     value,
                     config.web3_config.w3.to_wei(topup_ocean_bal, "ether"),
                     config.web3_config.owner,
                     True,
                 )
-                owner_ocean_balance=owner_ocean_balance-topup_ocean_bal
+                owner_ocean_balance = owner_ocean_balance - topup_ocean_bal
             else:
                 failed = True
                 print("Not enough OCEAN :(")
         if minimum_rose_bal > 0 and rose_bal < minimum_rose_bal:
             print(f"\t Transfering {topup_rose_bal} ROSE to {value}...")
-            if owner_rose_balance>topup_rose_bal:
+            if owner_rose_balance > topup_rose_bal:
                 rose.transfer(
                     value,
                     config.web3_config.w3.to_wei(topup_rose_bal, "ether"),
                     config.web3_config.owner,
                     True,
                 )
-                owner_rose_balance=owner_rose_balance-topup_rose_bal
+                owner_rose_balance = owner_rose_balance - topup_rose_bal
             else:
                 failed = True
                 print("Not enough ROSE :(")
     if failed:
-        exit(1)
+        sys.exit(1)
     else:
-        exit(0)
+        sys.exit(0)

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     owner_rose_balance = int(rose.balanceOf(config.web3_config.owner)) / 1e18
     print(
         f"Topup address ({config.web3_config.owner}) has "
-        + "{owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n"
+        + f"{owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n"
     )
     total_ocean = 0
     total_rose = 0

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -67,3 +67,7 @@ if __name__ == "__main__":
             else:
                 failed = True
                 print("Not enough ROSE :(")
+    if failed:
+        exit(1)
+    else:
+        exit(0)

--- a/scripts/topup.py
+++ b/scripts/topup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
     owner_ocean_balance=int(ocean_token.balanceOf(config.web3_config.owner))/1e18
     owner_rose_balance=int(rose.balanceOf(config.web3_config.owner))/1e18
-    print(f"Topup address has : {owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n")
+    print(f"Topup address ({config.web3_config.owner}) has : {owner_ocean_balance:.2f} OCEAN and {owner_rose_balance:.2f} ROSE\n\n")
     total_ocean=0
     total_rose=0
     for name, value in addresses.items():


### PR DESCRIPTION
Changes proposed in this PR:

- cosmetic changes to topup.py
- add cron to run every 6 hours, for both mainnet and testnet.   Private key is already set in secrets and bitwarden
- for reference, topup address is 0xbadDf37EbE3763f7c1D1245b1B241c246b96D3dF


Why:
  - Main account should not be used in crons.  Sometimes, we have large amount of tokens in that address. So let's use another one, with small amounts
  - Right now, the script is running on my pc, 24/7.  Let's move it to github
  
Logs from testing:
 - mainnet:  https://github.com/oceanprotocol/pdr-backend/actions/runs/6753225972/job/18359473261?pr=304
 - testnet:  https://github.com/oceanprotocol/pdr-backend/actions/runs/6753225972/job/18359473189?pr=304