### PR TITLE
Increase default subgraph timeout and retry count

### DIFF
--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -321,11 +321,9 @@ def get_pending_slots(
             chunk_size,
         )
 
-        print(query)
-
         offset += chunk_size
         try:
-            result = query_subgraph(subgraph_url, query, 0, 0.001)
+            result = query_subgraph(subgraph_url, query)
             if not "data" in result:
                 print("No data in result")
                 break


### PR DESCRIPTION
Fixes #389

Changes proposed in this PR:

- Increase default subgraph timeout and retry count.

pdr-backend often makes heavy queries to subgraph, increasing these will reduce the error rate.