### PR TITLE
For barge#391: update to *not* use barge's predictoor branch

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
         name: Checkout Barge
         with:
           repository: "oceanprotocol/barge"
-          ref: "predictoor"
+          ref: "main"
           path: "barge"
 
       - name: Run Barge

--- a/READMEs/barge.md
+++ b/READMEs/barge.md
@@ -29,9 +29,6 @@ Reference: how to run barge with...
 git clone https://github.com/oceanprotocol/barge
 cd barge
 
-# Switch to predictoor branch of barge repo
-git checkout predictoor
-
 # Clean up previous Ocean-related dirs & containers (optional but recommended) 
 rm -rf ~/.ocean
 ./cleanup.sh

--- a/READMEs/vps.md
+++ b/READMEs/vps.md
@@ -114,7 +114,6 @@ mkdir code
 cd code
 git clone https://github.com/oceanprotocol/barge
 cd barge
-git checkout predictoor
 ```
 
 ## 3. In VPS, Run Predictoor Barge


### PR DESCRIPTION
Towards [barge#391](https://github.com/oceanprotocol/barge/issues/391)

In predictoor repo, for its (a) github actions and (b) READMEs on running barge: update to _not_ use `predictoor` branch
- In predictoor `main` branch