### PR TITLE
#402 - Query Payouts: only get concluded slots

### DIFF
--- a/pdr_backend/util/subgraph.py
+++ b/pdr_backend/util/subgraph.py
@@ -98,7 +98,7 @@ def query_pending_payouts(subgraph_url: str, addr: str) -> Dict[str, List[int]]:
         query = """
         {
                 predictPredictions(
-                    where: {user: "%s", payout: null}, first: %s, skip: %s
+                    where: {user: "%s", payout: null, slot_: {status: "Paying"} }, first: %s, skip: %s
                 ) {
                     id
                     timestamp


### PR DESCRIPTION
Fixes #402

Changes proposed in this PR:

- Only get the slots where trueval has been submitted.