### PR TITLE
Fix #517: aimodel_data_factory.py missing data: binance:BTC/USDT:None

### DIFF
--- a/pdr_backend/ppss/aimodel_ss.py
+++ b/pdr_backend/ppss/aimodel_ss.py
@@ -20,6 +20,9 @@ class AimodelSS(MultiFeedMixin, StrMixin):
         # test inputs
         if self.approach not in APPROACHES:
             raise ValueError(self.approach)
+        for feed in self.feeds:
+            if feed.signal is None:
+                raise ValueError(f"Got signal=None for feed: {feed}")
 
         assert 0 < self.max_n_train
         assert 0 < self.autoregressive_n < np.inf

--- a/pdr_backend/ppss/test/test_aimodel_ss.py
+++ b/pdr_backend/ppss/test/test_aimodel_ss.py
@@ -6,7 +6,7 @@ from pdr_backend.ppss.aimodel_ss import APPROACHES, AimodelSS
 
 
 @enforce_types
-def test_aimodel_ss1():
+def test_aimodel_ss_happy1():
     d = {
         "approach": "LIN",
         "max_n_train": 7,
@@ -37,7 +37,7 @@ def test_aimodel_ss1():
 
 
 @enforce_types
-def test_aimodel_ss2():
+def test_aimodel_ss_happy2():
     for approach in APPROACHES:
         ss = AimodelSS(
             {
@@ -58,3 +58,17 @@ def test_aimodel_ss2():
                 "input_feeds": ["binance BTC/USDT c"],
             }
         )
+
+@enforce_types
+def test_aimodel_ss_unhappy1():
+
+    d = {
+        "approach": "LIN",
+        "max_n_train": 7,
+        "autoregressive_n": 3,
+        "input_feeds": ["kraken ETH/USDT"], # missing a signal like "c"
+    }
+
+    # it should complain that it's missing a signal in input feeds
+    with pytest.raises(ValueError):
+        AimodelSS(d)

--- a/ppss.yaml
+++ b/ppss.yaml
@@ -16,8 +16,9 @@ predictoor_ss:
   approach3:
   aimodel_ss:
     input_feeds:
-      - binance BTC/USDT
-#    - binance BTC/USDT ETH/USDT BNB/USDT XRP/USDT ADA/USDT DOGE/USDT SOL/USDT LTC/USDT TRX/USDT DOT/USDT
+      - binance BTC/USDT c
+#      - binance BTC/USDT ohlcv
+#      - binance BTC/USDT ETH/USDT BNB/USDT XRP/USDT ADA/USDT DOGE/USDT SOL/USDT LTC/USDT TRX/USDT DOT/USDT c
 #    - kraken BTC/USDT
     max_n_train: 5000 # no. epochs to train model on
     autoregressive_n : 10 # no. epochs that model looks back, to predict next


### PR DESCRIPTION
Fixes #517

The core issue was: ppss.yaml's aimodel_ss feeds section didn't have eg "c" or "ohlcv"; it assumed that they didn't need to be specified. This was an incorrect assumption: aimodel_ss needs it. In fact aimodel_ss class supports these signals, but the yaml file didn't have it.

What this PR does:
- add a test to aimodel_ss class constructor that complains if not specified
- do specify signals in the ppss.yaml file