### PR TITLE
#507: fix asyncio issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requirements = [
     "pyarrow",
     "pylint",
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio==0.21.1",
     "pytest-env",
     "pyyaml",
     "requests",


### PR DESCRIPTION
Work on #507.
Asyncio has some known issues, per their changelog. Namely issues with fixture handling etc., which I believe causes the warnings and test skips in our runs. They recommend using the previous version until they are fixed. It is also why my setup didn't spew up any warnings, my asyncio version was 21.1.

https://pytest-asyncio.readthedocs.io/en/latest/reference/changelog.html

I am wondering if I should mark #507 as closed or not. I do suggest keeping this around if newer versions of asyncio will work as expected, and we can remove the strict version setting in setup.py. Thoughts, @trentmc?