### PR TITLE
Subgraph 503 error

### DIFF
--- a/pdr_backend/analytics/test/test_get_traction_info.py
+++ b/pdr_backend/analytics/test/test_get_traction_info.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import polars as pl
+import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.analytics.get_traction_info import get_traction_info_main
@@ -88,3 +89,12 @@ def test_get_traction_info_empty(tmpdir, capfd):
     assert (
         "No records found. Please adjust start and end times." in capfd.readouterr().out
     )
+
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 503
+        # don't actually sleep in tests
+        with patch("time.sleep"):
+            with pytest.raises(Exception):
+                get_traction_info_main(ppss, st_timestr, fin_timestr, "parquet_data/")
+
+    assert mock_post.call_count == 3

--- a/pdr_backend/subgraph/core_subgraph.py
+++ b/pdr_backend/subgraph/core_subgraph.py
@@ -1,3 +1,4 @@
+import time
 from typing import Dict
 
 import requests
@@ -18,13 +19,17 @@ def query_subgraph(
     @return
       result -- e.g. {"data" : {"predictContracts": ..}}
     """
-    request = requests.post(subgraph_url, "", json={"query": query}, timeout=timeout)
-    if request.status_code != 200:
+    response = requests.post(subgraph_url, "", json={"query": query}, timeout=timeout)
+    if response.status_code != 200:
         # pylint: disable=broad-exception-raised
         if tries < SUBGRAPH_MAX_TRIES:
+            time.sleep(((tries + 1) / 2) ** (2) * 10)
             return query_subgraph(subgraph_url, query, tries + 1)
+
         raise Exception(
-            f"Query failed. Url: {subgraph_url}. Return code is {request.status_code}\n{query}"
+            f"Query failed. Url: {subgraph_url}. Return code is {response.status_code}\n{query}"
         )
-    result = request.json()
+
+    result = response.json()
+
     return result


### PR DESCRIPTION
Closes #511.
I couldn't actually fix the error, but I added a time.sleep part identical to the one in web3, which should provide for enough time for subgraph to respond. I can confirm the issue was subgraph being unavailable and the next retry was instantaneous instead of waiting.