### PR TITLE
#536 - Fix the value error when claiming ROSE rewards

### DIFF
--- a/pdr_backend/payout/payout.py
+++ b/pdr_backend/payout/payout.py
@@ -94,7 +94,7 @@ def do_rose_payout(ppss: PPSS, check_network: bool = True):
 
     print("Converting wROSE to ROSE")
     time.sleep(10)
-    wROSE = WrappedToken(web3_config, wROSE_addr)
+    wROSE = WrappedToken(ppss.web3_pp, wROSE_addr)
     wROSE_bal = wROSE.balanceOf(web3_config.owner)
     if wROSE_bal == 0:
         print("wROSE balance is 0")


### PR DESCRIPTION
Fixes #536

Changes proposed in this PR:

- [Pass the ppss.web3_pp instead of web3_config into WrappedToken class](https://github.com/oceanprotocol/pdr-backend/commit/5cc1a47a8f7c615d833ce36dbe0bcf5278034066)