### PR TITLE
Fix #557: Updated address/network exception handling + messaging to be more user friendly

### DIFF
--- a/pdr_backend/util/contract.py
+++ b/pdr_backend/util/contract.py
@@ -17,8 +17,16 @@ def get_address(web3_pp, contract_name: str):
     """
     network = get_addresses(web3_pp)
     if not network:
-        raise ValueError(f"Cannot figure out {contract_name} address")
+        raise ValueError(f'Cannot find network "{web3_pp.network}" in addresses.json')
+
     address = network.get(contract_name)
+    if not address:
+        error = (
+            f'Cannot find contract "{contract_name}" in address.json '
+            f'for network "{web3_pp.network}"'
+        )
+        raise ValueError(error)
+
     return address
 
 


### PR DESCRIPTION
Fixes #557

Changes proposed in this PR:
- [x] Improve the error handling and messaging around `get_address(contract_name)` so that it's more specific with issues surrounding address.json, networks, and contract lookups