### PR TITLE
[Lake] Issue 495: TDD incremental pdr_predictions table

### DIFF
--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -226,12 +226,11 @@ class GQLDataFactory:
             cur_df = pl.read_parquet(filename)
             df = pl.concat([cur_df, df])
 
-            # check for duplicates and throw error if any found
+            # drop duplicates
             duplicate_rows = df.filter(pl.struct("ID").is_duplicated())
             if len(duplicate_rows) > 0:
-                raise Exception(
-                    f"Not saved. Duplicate rows found. {len(duplicate_rows)} rows: {duplicate_rows}"
-                )
+                print(f"Duplicate rows found. Dropping {len(duplicate_rows)} rows: {duplicate_rows}")
+            df = df.drop(duplicate_rows)
 
             df.write_parquet(filename)
             n_new = df.shape[0] - cur_df.shape[0]
@@ -239,3 +238,111 @@ class GQLDataFactory:
         else:  # write new file
             df.write_parquet(filename)
             print(f"  Just saved df with {df.shape[0]} rows to new file {filename}")
+
+
+    @enforce_types
+    def _post_fetch_process_truevals(self, dfs: Dict[str, pl.DataFrame]) -> pl.DataFrame:
+        """
+        @description
+          Merge the fetched data with the existing data in the parquet file.
+          This is where we do any post-fetch transformations.
+        """
+        st_ut = self.ppss.lake_ss.st_timestamp / 1000
+        fin_ut = self.ppss.lake_ss.fin_timestamp / 1000
+
+        # Work 1: update prediction based on truevals
+        # process recent truevals => update predictions
+        # fetch recent truevals added
+        truevals_df = dfs["pdr_truevals"].filter(
+            (pl.col("timestamp") >= st_ut) & (pl.col("timestamp") <= fin_ut)
+        )
+        truevals_ids = truevals_df["ID"].to_list()
+
+        # find the predictions we'll be updating
+        print(f"post_truevals pdr_truevals: {truevals_ids}")
+        predictions_df = dfs["pdr_predictions"].filter(
+            (pl.col("truevalue_id").is_in(truevals_ids))
+        ).drop(
+            ["truevalue"]
+        )
+
+        # update specific predictions
+        predictions_df = predictions_df.join(
+            truevals_df,
+            left_on=["truevalue_id"],
+            right_on=["ID"],
+            how="left"
+        ).with_columns([
+            pl.col("truevalue").alias("truevalue"),
+        ]).select([
+            "ID",
+            "truevalue_id",
+            "contract",
+            "pair",
+            "timeframe",
+            "prediction",
+            "stake",
+            "truevalue",
+            "timestamp",
+            "source",
+            "payout",
+            "slot",
+            "user",
+        ])
+
+        # save out updated predictions
+        # filename = self._parquet_filename("pdr_predictions")
+        # self._save_parquet(filename, predictions_df)
+        predictions_df.write_parquet("pdr_predictions.parquet")
+
+
+    @enforce_types
+    def _post_fetch_process_payouts(self, dfs: Dict[str, pl.DataFrame]) -> pl.DataFrame:
+        """
+        @description
+          Merge the fetched data with the existing data in the parquet file.
+          This is where we do any post-fetch transformations.
+        """
+        st_ut = self.ppss.lake_ss.st_timestamp / 1000
+        fin_ut = self.ppss.lake_ss.fin_timestamp / 1000
+
+        # Work 2: update prediction based on payouts
+        # process recent payouts => update predictions
+        # fetch recent payouts added
+        payouts_df = dfs["pdr_payouts"].filter(
+            (pl.col("timestamp") >= st_ut) & (pl.col("timestamp") <= fin_ut)
+        )
+        payouts_ids = payouts_df["ID"].to_list()
+
+        # find all predictions that we'll be updating
+        predictions_df = dfs["pdr_predictions"].filter(
+            (pl.col("ID").is_in(payouts_ids))
+        ).drop(
+            ["payout", "predvalue"]
+        )
+
+        # update specific predictions
+        predictions_df = predictions_df.join(
+            payouts_df,
+            on="ID",
+            how="left"
+        ).select([
+            "ID",
+            "truevalue_id",
+            "contract",
+            "pair",
+            "timeframe",
+            "prediction",
+            "stake",
+            "truevalue",
+            "timestamp",
+            "source",
+            "payout",
+            "slot",
+            "user",
+        ])
+
+        # save out updated predictions
+        # filename = self._parquet_filename("pdr_predictions")
+        # self._save_parquet(filename, predictions_df)
+        predictions_df.write_parquet("pdr_predictions.parquet")

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -318,7 +318,7 @@ class GQLDataFactory:
         predictions_df = dfs["pdr_predictions"].filter(
             (pl.col("ID").is_in(payouts_ids))
         ).drop(
-            ["payout", "predvalue"]
+            ["payout", "prediction"]
         )
 
         # update specific predictions
@@ -326,7 +326,9 @@ class GQLDataFactory:
             payouts_df,
             on="ID",
             how="left"
-        ).select([
+        ).with_columns([
+            pl.col("predvalue").alias("prediction"),
+        ]).select([
             "ID",
             "truevalue_id",
             "contract",

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -8,6 +8,7 @@ from pdr_backend.lake.table_pdr_predictions import predictions_schema
 from pdr_backend.lake.test.resources import _gql_data_factory, _filter_gql_config
 from pdr_backend.subgraph.subgraph_predictions import FilterMode
 from pdr_backend.util.timeutil import timestr_to_ut
+from pdr_backend.subgraph.prediction import mock_prediction
 
 # ====================================================================
 # test parquet updating
@@ -352,3 +353,307 @@ def test_load_missing_parquet(
     dfs = gql_data_factory.get_gql_dfs()
     assert len(dfs[predictions_table]) == 2
     assert len(dfs[subscriptions_table]) == 0
+
+
+
+# ====================================================================
+# test post-fetch data processing tables
+
+_PREDICTIONS = [
+    (
+        "0xeeee",
+        "ETH/USDT",
+        "5m",
+        None,
+        None,
+        None,
+        1698865200,  # Nov 01 2023 19:00:00 GMT
+        "binance",
+        None,
+        1698865100,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+    (
+        "0xbbbb",
+        "BTC/USDT",
+        "1h",
+        None,
+        None,
+        None,
+        1698951500,  # Nov 02 2023 19:00:00 GMT
+        "binance",
+        None,
+        1698951600,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+    (
+        "0xaaaa",
+        "ADA/USDT",
+        "5m",
+        None,
+        None,
+        None,
+        1699037900,  # Nov 03 2023 19:00:00 GMT
+        "binance",
+        None,
+        1699038000,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+    (
+        "0xbnnn",
+        "BNB/USDT",
+        "1h",
+        None,
+        None,
+        None,
+        1699124300,  # Nov 04 2023 19:00:00 GMT
+        "kraken",
+        None,
+        1699124400,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+    (
+        "0xeeee",
+        "ETH/USDT",
+        "1h",
+        None,
+        None,
+        None,
+        1699214300,  # Nov 05 2023 19:00:00 GMT
+        "binance",
+        None,
+        1699214400,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+    (
+        "0xeeee",
+        "ETH/USDT",
+        "5m",
+        None,
+        None,
+        None,
+        1699300700,  # Nov 06 2023 19:00:00 GMT
+        "binance",
+        None,
+        1699300800,
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+    ),
+]
+
+@enforce_types
+def mock_predictions():
+    predictions = []
+    for pred_tuple in _PREDICTIONS:
+        (
+            contract,
+            pair_str,
+            timeframe_str,
+            prediction,
+            stake,
+            truevalue,
+            timestamp,
+            source,
+            payout,
+            slot,
+            user,
+        ) = pred_tuple
+
+        ID = f"{contract}-{slot}-{user}"
+        truevalue_id = f"{contract}-{slot}"
+
+        predictions.append({
+            "ID": ID,
+            "truevalue_id": truevalue_id,
+            "contract": contract,
+            "pair": pair_str,
+            "timeframe": timeframe_str,
+            "prediction": prediction,
+            "stake": stake,
+            "truevalue": truevalue,
+            "timestamp": timestamp,
+            "source": source,
+            "payout": payout,
+            "slot": slot,
+            "user": user,
+        })
+
+    return predictions
+
+_TRUEVALS = [
+    (
+        "0xeeee-1698865200", #id
+        "0xeeee", #contract
+        True, # truevalue
+        1698865201, # timestamp
+        1698865200, # Nov 01 2023 19:00:00 GMT
+    ),
+    (
+        "0xbbbb-1698951600", #id
+        "0xbbbb", #contract
+        False, # truevalue
+        1698951601, # timestamp        
+        1698951600, # Nov 02 2023 19:00:00 GMT
+    ),
+    (
+        "0xaaaa-1699038000", #id
+        "0xaaaa", #contract
+        False, # truevalue
+        1699038001, # timestamp
+        1699038000, # Nov 03 2023 19:00:00 GMT
+    ),
+    (
+        "0xbnnn-1699124400", #id
+        "0xbnnn", #contract
+        True, # truevalue
+        1699124401, # timestamp
+        1699124400, # Nov 04 2023 19:00:00 GMT
+    ),
+    (
+        "0xeeee-1699300800", #id
+        "0xeeee", #contract
+        False, # truevalue
+        1699300801, # timestamp
+        1699300800, # Nov 06 2023 19:00:00 GMT
+    )
+]
+
+def mock_truevals():
+    truevals = []
+    for trueval in _TRUEVALS:
+        (
+            ID,
+            contract,
+            truevalue,
+            timestamp,
+            slot
+        ) = trueval
+
+        truevals.append({
+            "ID": ID,
+            "contract": contract,
+            "truevalue": truevalue,
+            "timestamp": timestamp,
+            "slot": slot
+        })
+    return truevals
+
+_PAYOUTS = [
+    (
+        "0xeeee-1698865200-0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+        "0xeeee", #contract
+        1698865200,  # Nov 01 2023 19:00:00 GMT # slot
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd", #user
+        "5.464642693189679", #stake
+        "0", #payout
+        True, #predictedValue
+        False, #trueValue
+        1698865202, #timestamp
+    ),
+    (
+        "0xbbbb-1698951600-0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+        "0xbbbb", #contract
+        1698951600,  # Nov 02 2023 19:00:00 GMT # slot
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd", #user
+        "5.464642693189679", #stake
+        "10.928642693189679", #payout
+        False, #predictedValue
+        False, #trueValue
+        1698951602, #timestamp
+    ),
+    (
+        "0xaaaa-1699038000-0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+        "0xaaaa", #contract
+        1699038000, # Nov 03 2023 19:00:00 GMT
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd", #user
+        "3.4600000000000004", #stake
+        "7.041434095860760067", #payout
+        False, #predictedValue
+        False, #trueValue
+        1699038002, #timestamp
+    ),
+    (
+        "0xbnnn-1699124400-0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+        "0xbnnn", #contract
+        1699124400, # Nov 04 2023 19:00:00 GMT
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd", #user
+        "3.4600000000000004", #stake
+        "7.160056238874628619", #payout
+        True, #predictedValue
+        True, #trueValue
+        1699124402, #timestamp
+    ),
+    (
+        "0xeeee-1699300800-0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
+        "0xeeee", #contract
+        1699300800, # Nov 06 2023 19:00:00 GMT
+        "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd", #user
+        "3.4600000000000004", #stake
+        "0", #payout
+        True, #predictedValue
+        False, #trueValue
+        1699300802, #timestamp
+    ),
+]
+
+def mock_payouts():
+    payouts = []
+    for _payout in _PAYOUTS:
+        (
+            ID,
+            contract,
+            slot,
+            user,
+            stake,
+            payout,
+            predvalue,
+            truevalue,
+            timestamp,
+        ) = _payout
+
+        payouts.append({
+            "ID": ID,
+            "contract": contract,
+            "slot": slot,
+            "user": user,
+            "stake": stake,
+            "payout": payout,
+            "predvalue": predvalue,
+            "truevalue": truevalue,
+            "timestamp": timestamp,
+        })
+    return payouts
+
+@enforce_types
+def test_post_tables(tmpdir,monkeypatch):
+    # setup test
+    st_timestr = "2023-11-02_0:00"
+    fin_timestr = "2023-11-07_0:00"
+    
+    _, gql_data_factory = _gql_data_factory(
+        tmpdir,
+        "binanceus ETH/USDT h 5m",
+        st_timestr,
+        fin_timestr,
+    )
+
+    predictions = mock_predictions()
+    truevals = mock_truevals()
+    payouts = mock_payouts()
+
+    gql_dfs = {
+        "pdr_predictions": pl.DataFrame(predictions),
+        "pdr_truevals": pl.DataFrame(truevals),
+        "pdr_payouts": pl.DataFrame(payouts)
+    }
+
+    print("\n\ngql_dfs",gql_dfs)
+
+    # process post truevals
+    gql_data_factory._post_fetch_process_truevals(gql_dfs)
+    predictions_df = pl.read_parquet("pdr_predictions.parquet")
+    print(">>> truevals saved_parquet predictions_df", predictions_df)
+
+    # process post payouts
+    gql_data_factory._post_fetch_process_payouts(gql_dfs)
+    predictions_df = pl.read_parquet("pdr_predictions.parquet")
+    print(">>> payouts saved_parquet predictions_df", predictions_df)

--- a/pdr_backend/subgraph/prediction.py
+++ b/pdr_backend/subgraph/prediction.py
@@ -9,6 +9,7 @@ class Prediction:
     def __init__(
         self,
         ID: str,
+        contract: str,
         pair: str,
         timeframe: str,
         prediction: Union[bool, None],  # prediction = subgraph.predicted_value
@@ -22,6 +23,11 @@ class Prediction:
         user: str,
     ) -> None:
         self.ID = ID
+        # self.prediction_id = f"{contract}-{slot}-{user}"
+        # self.payout_id = f"{contract}-{slot}-{user}"
+        # self.slot_id = f"{contract}-{slot}"
+        # self.trueval_id = f"{contract}-{slot}"
+        self.contract = contract
         self.pair = pair
         self.timeframe = timeframe
         self.prediction = prediction
@@ -42,6 +48,7 @@ class Prediction:
 @enforce_types
 def mock_prediction(prediction_tuple: tuple) -> Prediction:
     (
+        contract,
         pair_str,
         timeframe_str,
         prediction,
@@ -55,9 +62,10 @@ def mock_prediction(prediction_tuple: tuple) -> Prediction:
         user,
     ) = prediction_tuple
 
-    ID = f"{address}-{slot}-{user}"
+    ID = f"{contract}-{slot}-{user}"
     return Prediction(
         ID=ID,
+        contract=contract,
         pair=pair_str,
         timeframe=timeframe_str,
         prediction=prediction,
@@ -96,6 +104,7 @@ def mock_daily_predictions() -> List[Prediction]:
 
 _FIRST_PREDICTION_TUPS = [
     (
+        "0xaaaa",
         "ADA/USDT",
         "5m",
         True,
@@ -109,6 +118,7 @@ _FIRST_PREDICTION_TUPS = [
         "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xbbbb",
         "BTC/USDT",
         "5m",
         True,
@@ -125,6 +135,7 @@ _FIRST_PREDICTION_TUPS = [
 
 _SECOND_PREDICTION_TUPS = [
     (
+        "0xeeee",
         "ETH/USDT",
         "5m",
         True,
@@ -138,6 +149,7 @@ _SECOND_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xbbbb",
         "BTC/USDT",
         "1h",
         True,
@@ -151,6 +163,7 @@ _SECOND_PREDICTION_TUPS = [
         "0xbbbb4cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xaaaa",
         "ADA/USDT",
         "5m",
         True,
@@ -164,6 +177,7 @@ _SECOND_PREDICTION_TUPS = [
         "0xbbbb4cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xbnnn",
         "BNB/USDT",
         "1h",
         True,
@@ -177,6 +191,7 @@ _SECOND_PREDICTION_TUPS = [
         "0xbbbb4cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xeeee",
         "ETH/USDT",
         "1h",
         True,
@@ -190,6 +205,7 @@ _SECOND_PREDICTION_TUPS = [
         "0xcccc4cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xeeee",
         "ETH/USDT",
         "5m",
         True,
@@ -206,6 +222,7 @@ _SECOND_PREDICTION_TUPS = [
 
 _DAILY_PREDICTION_TUPS = [
     (
+        "0xeeee",
         "ETH/USDT",
         "5m",
         True,
@@ -219,6 +236,7 @@ _DAILY_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xbbbb",
         "BTC/USDT",
         "1h",
         True,
@@ -232,6 +250,7 @@ _DAILY_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xaaaa",
         "ADA/USDT",
         "5m",
         True,
@@ -245,6 +264,7 @@ _DAILY_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xbnnn",
         "BNB/USDT",
         "1h",
         True,
@@ -258,6 +278,7 @@ _DAILY_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xeeee",
         "ETH/USDT",
         "1h",
         True,
@@ -271,6 +292,7 @@ _DAILY_PREDICTION_TUPS = [
         "0xd2a24cb4ff2584bad80ff5f109034a891c3d88dd",
     ),
     (
+        "0xeeee",
         "ETH/USDT",
         "5m",
         True,


### PR DESCRIPTION
It was @idiom-bytes PR, I just created a new branch and I did a cherry-pick from his work.

I left the original message below:

### Motivation
As described in #482 create the basic set of functionality required to create/update the <post_pdr_predictions> table incrementally.

Consider the order of events, and how rows will be created/updated. 
1. Predictions
2. Truevals
3. Payouts

### Incremental update of post_pdr_predictions table
This implementation was provided as a way to not change any of the raw data. Instead, it creates a new table post_pdr_predictions.
1. from pdr_predictions_table - get new predictions from latest update (may already have up-to-now truevals, payouts) and append to post_pdr_predictions
1. from pdr_truevals_table - get new truevals for slots older than latest update (skip new truevals for up-to-now predictions).
1. from pdr_payouts_table - get new payouts for slots older than latest update (skip new payouts for up-to-now predictions).
1. left join existing post_pdr_predictions rows using (2)(3) as filters to reduce join size
1. function returns final, incremental, post_pdr_predictions df

### Incremental update of existing pdr_predictions table
This implementation modifies the subgraph raw data that is saved locally, such that it's up-to-date with what subgraph would provide. This updates the pdr_predictions table, which can then be consumed directly.
1. from pdr_truevals_table - get new truevals for slots older than latest update (skip new truevals for up-to-now predictions).
1. from pdr_payouts_table - get new payouts for slots older than latest update (skip new payouts for up-to-now predictions).
1. left join existing pdr_predictions rows using (2)(3) as filters to reduce join size
1. function returns final, updated, pdr_predictions df

Polars/Parquet currently doesn't support partitions, but it does support pre-filtering w/ timestamp. Focus on the least amount of work required to complete the dataframe/steps.

### DoD:
- [ ] Tests verify that <post_pdr_predictions> table is being built and updated correctly
- [ ] Tests have access to Predictions, Truevals, Payouts event/data
- [ ] Tests cover different data flows/scenarios for what's available during each run
- [ ] Tests covers logic that minimizes total number of records processed.
1. Test that new trueval events update existing post_prediction records
1. Test that new payout events update existing post_prediction records.
1. Test that only new prediction events are appended, and unnecessary updates are being minimized.
1. Test that unnecessary trueval and payout updates are being minimized.
1. Test that post_prediction records, and downstream records are updated incrementally.