### PR TITLE
Run newer (upgraded) black.

### DIFF
--- a/pdr_backend/accuracy/app.py
+++ b/pdr_backend/accuracy/app.py
@@ -122,9 +122,9 @@ def aggregate_statistics(
         and the total counts of correct predictions and slots evaluated.
     """
 
-    total_staked_yesterday = (
-        total_staked_today
-    ) = total_correct_predictions = total_slots_evaluated = 0
+    total_staked_yesterday = total_staked_today = total_correct_predictions = (
+        total_slots_evaluated
+    ) = 0
     for slot in slots:
         slot_results = process_single_slot(slot, end_of_previous_day_timestamp)
         if slot_results:

--- a/pdr_backend/analytics/predictoor_stats.py
+++ b/pdr_backend/analytics/predictoor_stats.py
@@ -229,9 +229,11 @@ def calculate_slot_daily_statistics(
     slots_daily_df = (
         slots_df.group_by(["pair_timeframe", "datetime"])
         .map_groups(
-            lambda df: get_mean_slots_slots_df(df.sample(5))
-            if len(df) > 5
-            else get_mean_slots_slots_df(df)
+            lambda df: (
+                get_mean_slots_slots_df(df.sample(5))
+                if len(df) > 5
+                else get_mean_slots_slots_df(df)
+            )
         )
         .group_by("datetime")
         .agg(

--- a/pdr_backend/lake/plutil.py
+++ b/pdr_backend/lake/plutil.py
@@ -2,6 +2,7 @@
 plutil: polars dataframe & csv/parquet utilities. 
 These utilities are specific to the time-series dataframe columns we're using.
 """
+
 import os
 import shutil
 from io import StringIO

--- a/pdr_backend/predictoor/base_predictoor_agent.py
+++ b/pdr_backend/predictoor/base_predictoor_agent.py
@@ -11,7 +11,6 @@ from pdr_backend.util.mathutil import sole_value
 
 
 class BasePredictoorAgent(ABC):
-
     """
     What it does
     - Fetches Predictoor contracts from subgraph, and filters them

--- a/pdr_backend/predictoor/test/predictoor_agent_runner.py
+++ b/pdr_backend/predictoor/test/predictoor_agent_runner.py
@@ -2,6 +2,7 @@
 This file exposes run_agent_test()
 which is used by test_predictoor_agent{1,3}.py
 """
+
 import os
 
 from enforce_typing import enforce_types


### PR DESCRIPTION
Currently, the black version from CIs is updated, but the files were left behind (with the previous auto formatting), resulting in CI failure for unrelated PRs. This is just a `black` run using the updated version.