### PR TITLE
Fix #582: Make ppss.yaml copy directions more explicit

### DIFF
--- a/READMEs/predictoor.md
+++ b/READMEs/predictoor.md
@@ -47,6 +47,9 @@ codesign --force --deep --sign - venv/sapphirepy_bin/sapphirewrapper-arm64.dylib
 Simulation allows us to quickly build intuition, and assess the performance of the data / predicting / trading strategy (backtest).
 
 Copy [`ppss.yaml`](../ppss.yaml) into your own file `my_ppss.yaml` and change parameters as you see fit.
+```console
+cp ppss.yaml my_ppss.yaml
+```
 
 Let's simulate! In console:
 ```console

--- a/READMEs/trader.md
+++ b/READMEs/trader.md
@@ -44,6 +44,9 @@ codesign --force --deep --sign - venv/sapphirepy_bin/sapphirewrapper-arm64.dylib
 Simulation allows us to quickly build intuition, and assess the performance of the data / predicting / trading strategy (backtest).
 
 Copy [`ppss.yaml`](../ppss.yaml) into your own file `my_ppss.yaml` and change parameters as you see fit.
+```console
+cp ppss.yaml my_ppss.yaml
+```
 
 Let's simulate! In console:
 ```console


### PR DESCRIPTION
Fix #582.

Changes proposed in this PR:
- Added a small code block to the Sim flow readme for `cp ppss.yaml to my_ppss.yaml`
