### PR TITLE
Move address utils to web3 pp.

### DIFF
--- a/pdr_backend/analytics/check_network.py
+++ b/pdr_backend/analytics/check_network.py
@@ -164,8 +164,7 @@ def check_network_main(ppss: PPSS, lookback_hours: int):
     addresses = get_opf_addresses(web3_pp.network)
     for name, address in addresses.items():
         ocean_bal = from_wei(OCEAN.balanceOf(address))
-        # TODO: wrap in web3 pp?
-        native_bal = from_wei(web3_pp.web3_config.w3.eth.get_balance(address))
+        native_bal = from_wei(web3_pp.get_token_balance(address))
 
         ocean_warning = (
             " WARNING LOW OCEAN BALANCE!"

--- a/pdr_backend/analytics/test/test_check_network.py
+++ b/pdr_backend/analytics/test/test_check_network.py
@@ -86,7 +86,7 @@ def test_get_expected_consume():
 @patch(f"{PATH}.check_dfbuyer")
 @patch(f"{PATH}.get_opf_addresses")
 @patch(f"{PATH}.query_subgraph")
-@patch(f"{PATH}.Token")
+@patch("pdr_backend.ppss.web3_pp.Token")
 def test_check_network_main(  # pylint: disable=unused-argument
     mock_token,
     mock_query_subgraph,
@@ -118,7 +118,7 @@ def test_check_network_main(  # pylint: disable=unused-argument
 @enforce_types
 @patch(f"{PATH}.check_dfbuyer")
 @patch(f"{PATH}.get_opf_addresses")
-@patch(f"{PATH}.Token")
+@patch("pdr_backend.ppss.web3_pp.Token")
 def test_check_network_others(  # pylint: disable=unused-argument
     mock_token,
     mock_get_opf_addresses,
@@ -155,7 +155,7 @@ def test_check_network_others(  # pylint: disable=unused-argument
 @enforce_types
 @patch(f"{PATH}.check_dfbuyer")
 @patch(f"{PATH}.get_opf_addresses")
-@patch(f"{PATH}.Token")
+@patch("pdr_backend.ppss.web3_pp.Token")
 def test_check_network_without_mock(  # pylint: disable=unused-argument
     mock_token,
     mock_get_opf_addresses,

--- a/pdr_backend/cli/cli_module.py
+++ b/pdr_backend/cli/cli_module.py
@@ -22,7 +22,6 @@ from pdr_backend.sim.sim_engine import SimEngine
 from pdr_backend.trader.approach1.trader_agent1 import TraderAgent1
 from pdr_backend.trader.approach2.trader_agent2 import TraderAgent2
 from pdr_backend.trueval.trueval_agent import TruevalAgent
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.topup import topup_main
 from pdr_backend.util.core_accounts import fund_accounts_with_OCEAN
 from pdr_backend.util.web3_accounts import create_accounts, view_accounts, fund_accounts
@@ -208,7 +207,7 @@ def do_trueval(args, nested_args=None, testing=False):
         network=args.NETWORK,
         nested_override_args=nested_args,
     )
-    predictoor_batcher_addr = get_address(ppss.web3_pp, "PredictoorHelper")
+    predictoor_batcher_addr = ppss.web3_pp.get_address("PredictoorHelper")
     agent = TruevalAgent(ppss, predictoor_batcher_addr)
 
     agent.run(testing)

--- a/pdr_backend/conftest_ganache.py
+++ b/pdr_backend/conftest_ganache.py
@@ -7,7 +7,6 @@ from pdr_backend.contract.predictoor_contract import PredictoorContract
 from pdr_backend.contract.token import Token
 from pdr_backend.ppss.ppss import PPSS, fast_test_yaml_str
 from pdr_backend.publisher.publish_asset import publish_asset
-from pdr_backend.util.contract import get_address
 
 CHAIN_ID = 8996
 S_PER_EPOCH = 300
@@ -53,7 +52,7 @@ def _ppss():
 
 @pytest.fixture(scope="session")
 def ocean_token() -> Token:
-    token_address = get_address(_web3_pp(), "Ocean")
+    token_address = _web3_pp().get_address("Ocean")
     return Token(_web3_pp(), token_address)
 
 
@@ -127,5 +126,5 @@ def predictoor_contract_empty():
 @pytest.fixture(scope="module")
 def predictoor_batcher():
     w3p = _web3_pp()
-    predictoor_batcher_addr = get_address(w3p, "PredictoorHelper")
+    predictoor_batcher_addr = w3p.get_address("PredictoorHelper")
     return PredictoorBatcher(w3p, predictoor_batcher_addr)

--- a/pdr_backend/contract/base_contract.py
+++ b/pdr_backend/contract/base_contract.py
@@ -11,9 +11,6 @@ class BaseContract(ABC):
         # pylint: disable=import-outside-toplevel
         from pdr_backend.ppss.web3_pp import Web3PP
 
-        # pylint: disable=import-outside-toplevel
-        from pdr_backend.util.contract import get_contract_abi
-
         if not isinstance(web3_pp, Web3PP):
             raise ValueError(f"web3_pp is {web3_pp.__class__}, not Web3PP")
         self.web3_pp = web3_pp
@@ -21,7 +18,7 @@ class BaseContract(ABC):
         self.contract_address = self.config.w3.to_checksum_address(address)
         self.contract_instance = self.config.w3.eth.contract(
             address=self.config.w3.to_checksum_address(address),
-            abi=get_contract_abi(contract_name, web3_pp.address_file),
+            abi=web3_pp.get_contract_abi(contract_name),
         )
         self.contract_name = contract_name
 

--- a/pdr_backend/contract/erc721_factory.py
+++ b/pdr_backend/contract/erc721_factory.py
@@ -2,13 +2,12 @@ from enforce_typing import enforce_types
 from web3.logs import DISCARD
 
 from pdr_backend.contract.base_contract import BaseContract
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
 class Erc721Factory(BaseContract):
     def __init__(self, web3_pp):
-        address = get_address(web3_pp, "ERC721Factory")
+        address = web3_pp.get_address("ERC721Factory")
 
         if not address:
             raise ValueError("Cannot figure out Erc721Factory address")

--- a/pdr_backend/contract/test/test_base_contract.py
+++ b/pdr_backend/contract/test/test_base_contract.py
@@ -5,7 +5,6 @@ import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.contract.token import Token
-from pdr_backend.util.contract import get_address
 
 
 @pytest.fixture
@@ -17,7 +16,7 @@ def mock_send_encrypted_sapphire_tx(monkeypatch):
 
 @enforce_types
 def test_base_contract(web3_pp, web3_config):
-    OCEAN_address = get_address(web3_pp, "Ocean")
+    OCEAN_address = web3_pp.OCEAN_address
 
     # success
     Token(web3_pp, OCEAN_address)
@@ -34,7 +33,7 @@ def test_send_encrypted_tx(
     ocean_token,
     web3_pp,
 ):
-    OCEAN_address = get_address(web3_pp, "Ocean")
+    OCEAN_address = web3_pp.OCEAN_address
     contract = Token(web3_pp, OCEAN_address)
 
     # Set up dummy return value for the mocked function

--- a/pdr_backend/contract/test/test_data_nft.py
+++ b/pdr_backend/contract/test/test_data_nft.py
@@ -8,7 +8,6 @@ from web3.logs import DISCARD
 from pdr_backend.contract.data_nft import DataNft
 from pdr_backend.contract.erc721_factory import Erc721Factory
 from pdr_backend.util.constants import MAX_UINT
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import to_wei
 
 
@@ -28,8 +27,8 @@ def test_set_ddo(web3_pp, web3_config):
         private_key=private_key
     )
     factory = Erc721Factory(web3_pp)
-    ocean_address = get_address(web3_pp, "Ocean")
-    fre_address = get_address(web3_pp, "FixedPrice")
+    ocean_address = web3_pp.OCEAN_address
+    fre_address = web3_pp.get_address("FixedPrice")
 
     feeCollector = owner.address
 

--- a/pdr_backend/contract/test/test_dfrewards.py
+++ b/pdr_backend/contract/test/test_dfrewards.py
@@ -1,15 +1,14 @@
 from enforce_typing import enforce_types
 
 from pdr_backend.contract.dfrewards import DFRewards
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
 def test_dfrewards(web3_pp, web3_config):
-    dfrewards_addr = get_address(web3_pp, "DFRewards")
+    dfrewards_addr = web3_pp.get_address("DFRewards")
     assert isinstance(dfrewards_addr, str)
 
-    ocean_addr = get_address(web3_pp, "Ocean")
+    ocean_addr = web3_pp.OCEAN_address
     assert isinstance(dfrewards_addr, str)
 
     contract = DFRewards(web3_pp, dfrewards_addr)

--- a/pdr_backend/contract/test/test_erc721_factory.py
+++ b/pdr_backend/contract/test/test_erc721_factory.py
@@ -4,7 +4,6 @@ import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.contract.erc721_factory import Erc721Factory
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import to_wei
 
 
@@ -13,8 +12,8 @@ def test_Erc721Factory(web3_pp, web3_config):
     factory = Erc721Factory(web3_pp)
     assert factory is not None
 
-    ocean_address = get_address(web3_pp, "Ocean")
-    fre_address = get_address(web3_pp, "FixedPrice")
+    ocean_address = web3_pp.OCEAN_address
+    fre_address = web3_pp.get_address("FixedPrice")
 
     rate = 3
     cut = 0.2

--- a/pdr_backend/contract/test/test_erc721_factory.py
+++ b/pdr_backend/contract/test/test_erc721_factory.py
@@ -68,6 +68,6 @@ def test_Erc721Factory(web3_pp, web3_config):
 
 @enforce_types
 def test_Erc721Factory_no_address(web3_pp):
-    with patch("pdr_backend.contract.erc721_factory.get_address", return_value=None):
+    with patch.object(web3_pp, "get_address", return_value=None):
         with pytest.raises(ValueError):
             Erc721Factory(web3_pp)

--- a/pdr_backend/contract/test/test_predictoor_contract.py
+++ b/pdr_backend/contract/test/test_predictoor_contract.py
@@ -7,7 +7,6 @@ from pytest import approx
 from pdr_backend.conftest_ganache import S_PER_EPOCH
 from pdr_backend.contract.predictoor_contract import mock_predictoor_contract
 from pdr_backend.contract.token import Token
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import from_wei, to_wei
 
 
@@ -54,8 +53,7 @@ def test_get_exchanges(predictoor_contract):
 @enforce_types
 def test_get_stake_token(predictoor_contract, web3_pp):
     stake_token = predictoor_contract.get_stake_token()
-    ocean_address = get_address(web3_pp, "Ocean")
-    assert stake_token == ocean_address
+    assert stake_token == web3_pp.OCEAN_address
 
 
 @enforce_types

--- a/pdr_backend/contract/test/test_token.py
+++ b/pdr_backend/contract/test/test_token.py
@@ -4,12 +4,11 @@ from unittest.mock import patch
 from enforce_typing import enforce_types
 
 from pdr_backend.contract.token import NativeToken, Token
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
 def test_token(web3_pp, web3_config):
-    token_address = get_address(web3_pp, "Ocean")
+    token_address = web3_pp.OCEAN_address
     token = Token(web3_pp, token_address)
 
     accounts = web3_config.w3.eth.accounts

--- a/pdr_backend/contract/test/test_token.py
+++ b/pdr_backend/contract/test/test_token.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from enforce_typing import enforce_types
 
-from pdr_backend.contract.token import NativeToken, Token
+from pdr_backend.contract.token import Token
 
 
 @enforce_types

--- a/pdr_backend/contract/test/test_token.py
+++ b/pdr_backend/contract/test/test_token.py
@@ -32,7 +32,7 @@ def test_token(web3_pp, web3_config):
 
 @enforce_types
 def test_native_token(web3_pp):
-    token = NativeToken(web3_pp)
+    token = web3_pp.NativeToken
     assert token.w3
 
     owner = web3_pp.web3_config.owner

--- a/pdr_backend/contract/test/test_wrapped_token.py
+++ b/pdr_backend/contract/test/test_wrapped_token.py
@@ -3,12 +3,11 @@ from unittest.mock import Mock, patch
 from enforce_typing import enforce_types
 
 from pdr_backend.contract.wrapped_token import WrappedToken
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
 def test_native_token(web3_pp):
-    token_address = get_address(web3_pp, "Ocean")
+    token_address = web3_pp.get_address("Ocean")
     mock_wrapped_contract = Mock()
     mock_transaction = Mock()
     mock_transaction.transact.return_value = "mock_tx"

--- a/pdr_backend/dfbuyer/dfbuyer_agent.py
+++ b/pdr_backend/dfbuyer/dfbuyer_agent.py
@@ -13,7 +13,6 @@ from pdr_backend.subgraph.subgraph_consume_so_far import get_consume_so_far_per_
 from pdr_backend.subgraph.subgraph_feed import print_feeds
 from pdr_backend.subgraph.subgraph_sync import wait_until_subgraph_syncs
 from pdr_backend.util.constants import MAX_UINT
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import from_wei
 
 WEEK = 7 * 86400
@@ -37,8 +36,8 @@ class DFBuyerAgent:
             raise ValueError("No feeds found.")
 
         # addresses
-        batcher_addr = get_address(ppss.web3_pp, "PredictoorHelper")
-        self.OCEAN_addr = get_address(ppss.web3_pp, "Ocean")
+        batcher_addr = ppss.web3_pp.get_address("PredictoorHelper")
+        self.OCEAN_addr = ppss.web3_pp.OCEAN_address
 
         # set attribs to track progress
         self.last_consume_ts = 0

--- a/pdr_backend/dfbuyer/dfbuyer_agent.py
+++ b/pdr_backend/dfbuyer/dfbuyer_agent.py
@@ -37,7 +37,7 @@ class DFBuyerAgent:
 
         # addresses
         batcher_addr = ppss.web3_pp.get_address("PredictoorHelper")
-        self.OCEAN_addr = ppss.web3_pp.OCEAN_address
+        self.OCEAN_addr = ppss.web3_pp.get_address("Ocean")
 
         # set attribs to track progress
         self.last_consume_ts = 0

--- a/pdr_backend/dfbuyer/dfbuyer_agent.py
+++ b/pdr_backend/dfbuyer/dfbuyer_agent.py
@@ -7,7 +7,6 @@ from enforce_typing import enforce_types
 
 from pdr_backend.contract.predictoor_batcher import PredictoorBatcher
 from pdr_backend.contract.predictoor_contract import PredictoorContract
-from pdr_backend.contract.token import Token
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.subgraph.subgraph_consume_so_far import get_consume_so_far_per_contract
 from pdr_backend.subgraph.subgraph_feed import print_feeds
@@ -50,7 +49,7 @@ class DFBuyerAgent:
 
         # Check allowance and approve if necessary
         print("Checking allowance...")
-        OCEAN = Token(ppss.web3_pp, self.OCEAN_addr)
+        OCEAN = ppss.web3_pp.OCEAN_Token
         allowance = OCEAN.allowance(
             ppss.web3_pp.web3_config.owner,
             self.predictoor_batcher.contract_address,

--- a/pdr_backend/dfbuyer/test/conftest.py
+++ b/pdr_backend/dfbuyer/test/conftest.py
@@ -51,7 +51,5 @@ def mock_dfbuyer_agent(  # pylint: disable=unused-argument, redefined-outer-name
     mock_ppss,
     mock_PredictoorBatcher,
 ):
-    with patch.object(
-        mock_ppss.web3_pp, "get_address", return_value=ZERO_ADDRESS
-    ):
+    with patch.object(mock_ppss.web3_pp, "get_address", return_value=ZERO_ADDRESS):
         return DFBuyerAgent(mock_ppss)

--- a/pdr_backend/dfbuyer/test/conftest.py
+++ b/pdr_backend/dfbuyer/test/conftest.py
@@ -13,7 +13,7 @@ PATH = "pdr_backend.dfbuyer.dfbuyer_agent"
 
 @pytest.fixture()
 def mock_token():
-    with patch(f"pdr_backend.ppss.web3_pp.Token") as mock_token_class:
+    with patch("pdr_backend.ppss.web3_pp.Token") as mock_token_class:
         mock_token_instance = MagicMock()
         mock_token_instance.allowance.return_value = MAX_UINT
         mock_token_class.return_value = mock_token_instance

--- a/pdr_backend/dfbuyer/test/conftest.py
+++ b/pdr_backend/dfbuyer/test/conftest.py
@@ -11,13 +11,6 @@ from pdr_backend.util.constants import MAX_UINT, ZERO_ADDRESS
 PATH = "pdr_backend.dfbuyer.dfbuyer_agent"
 
 
-@pytest.fixture
-def mock_get_address():
-    with patch(f"{PATH}.get_address") as mock:
-        mock.return_value = ZERO_ADDRESS
-        yield mock
-
-
 @pytest.fixture()
 def mock_token():
     with patch(f"{PATH}.Token") as mock_token_class:
@@ -54,9 +47,11 @@ def mock_PredictoorBatcher(mock_ppss):  # pylint: disable=redefined-outer-name
 
 @pytest.fixture
 def mock_dfbuyer_agent(  # pylint: disable=unused-argument, redefined-outer-name
-    mock_get_address,
     mock_token,
     mock_ppss,
     mock_PredictoorBatcher,
 ):
-    return DFBuyerAgent(mock_ppss)
+    with patch.object(
+        mock_ppss.web3_pp, "get_address", return_value=ZERO_ADDRESS
+    ):
+        return DFBuyerAgent(mock_ppss)

--- a/pdr_backend/dfbuyer/test/conftest.py
+++ b/pdr_backend/dfbuyer/test/conftest.py
@@ -13,7 +13,7 @@ PATH = "pdr_backend.dfbuyer.dfbuyer_agent"
 
 @pytest.fixture()
 def mock_token():
-    with patch(f"{PATH}.Token") as mock_token_class:
+    with patch(f"pdr_backend.ppss.web3_pp.Token") as mock_token_class:
         mock_token_instance = MagicMock()
         mock_token_instance.allowance.return_value = MAX_UINT
         mock_token_class.return_value = mock_token_instance

--- a/pdr_backend/dfbuyer/test/test_dfbuyer_agent.py
+++ b/pdr_backend/dfbuyer/test/test_dfbuyer_agent.py
@@ -17,7 +17,6 @@ PATH = "pdr_backend.dfbuyer.dfbuyer_agent"
 
 @enforce_types
 def test_dfbuyer_agent_constructor(  # pylint: disable=unused-argument
-    mock_get_address,
     mock_token,
     mock_ppss,
     mock_PredictoorBatcher,
@@ -25,12 +24,6 @@ def test_dfbuyer_agent_constructor(  # pylint: disable=unused-argument
     mock_token.return_value.allowance.return_value = 0
 
     agent = DFBuyerAgent(mock_ppss)
-
-    assert len(mock_get_address.call_args_list) == 2
-    call1 = mock_get_address.call_args_list[0]
-    assert call1 == call(mock_ppss.web3_pp, "PredictoorHelper")
-    call2 = mock_get_address.call_args_list[1]
-    assert call2 == call(mock_ppss.web3_pp, "Ocean")
 
     mock_token.assert_called_with(mock_ppss.web3_pp, agent.OCEAN_addr)
     mock_token_instance = mock_token()
@@ -135,7 +128,6 @@ def test_dfbuyer_agent_prepare_batches(mock_dfbuyer_agent):
 
 @enforce_types
 def test_dfbuyer_agent_get_missing_consumes(  # pylint: disable=unused-argument
-    mock_get_address,
     mock_token,
     monkeypatch,
 ):

--- a/pdr_backend/dfbuyer/test/test_dfbuyer_agent.py
+++ b/pdr_backend/dfbuyer/test/test_dfbuyer_agent.py
@@ -138,6 +138,7 @@ def test_dfbuyer_agent_get_missing_consumes(  # pylint: disable=unused-argument
     feeds = {address: MagicMock() for address in addresses}
     ppss.web3_pp.query_feed_contracts = MagicMock()
     ppss.web3_pp.query_feed_contracts.return_value = feeds
+    ppss.web3_pp.OCEAN_Token.allowance.return_value = MAX_UINT
 
     ppss.dfbuyer_ss = MagicMock(spec=DFBuyerSS)
     ppss.dfbuyer_ss.batch_size = 3

--- a/pdr_backend/ppss/ppss.py
+++ b/pdr_backend/ppss/ppss.py
@@ -211,6 +211,7 @@ def mock_ppss(
             "weekly_spending_limit": 37000,
         }
     )
+
     return ppss
 
 

--- a/pdr_backend/ppss/test/test_web3_pp.py
+++ b/pdr_backend/ppss/test/test_web3_pp.py
@@ -216,9 +216,7 @@ def test_get_addresses():
 
     assert 'Cannot find network "development"' in str(excinfo.value)
 
-    return_value = {
-        "Ocean": "0x1234567890123456789012345678901234567890"
-    }
+    return_value = {"Ocean": "0x1234567890123456789012345678901234567890"}
     with patch.object(web3_pp, "get_addresses", return_value=return_value):
         with pytest.raises(ValueError) as excinfo:
             web3_pp.get_address("ERCUnknown")

--- a/pdr_backend/ppss/test/test_web3_pp.py
+++ b/pdr_backend/ppss/test/test_web3_pp.py
@@ -5,6 +5,7 @@ import pytest
 from enforce_typing import enforce_types
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
+from pdr_backend.util.constants import ZERO_ADDRESS
 
 from pdr_backend.contract.predictoor_contract import mock_predictoor_contract
 from pdr_backend.ppss.web3_pp import (
@@ -198,3 +199,30 @@ def test_tx_gas_price__and__tx_call_params():
         web3_pp.tx_gas_price()
     with pytest.raises(ValueError):
         web3_pp.tx_call_params()
+
+
+@enforce_types
+def test_get_addresses(mock_ppss):
+    network = "development"
+    ppss = mock_ppss(["binance BTC/USDT c 5m"], network)
+    web3_pp = ppss.web3_pp
+    assert web3_pp.network == network
+
+    web3_pp.get_addresses.return_value = None
+
+    # Work 1: validate network can't be found
+    with pytest.raises(ValueError) as excinfo:
+        web3_pp.OCEAN_address
+
+    assert 'Cannot find network "development"' in str(excinfo.value)
+
+    web3_pp.get_addresses.return_value = {
+        "Ocean": "0x1234567890123456789012345678901234567890"
+    }
+    with pytest.raises(ValueError) as excinfo:
+        web3_pp.get_address("ERCUnknown")
+
+    assert 'Cannot find contract "ERCUnknown"' in str(excinfo.value)
+
+    assert web3_pp.OCEAN_address == "0x1234567890123456789012345678901234567890"
+

--- a/pdr_backend/ppss/test/test_web3_pp.py
+++ b/pdr_backend/ppss/test/test_web3_pp.py
@@ -225,4 +225,3 @@ def test_get_addresses(mock_ppss):
     assert 'Cannot find contract "ERCUnknown"' in str(excinfo.value)
 
     assert web3_pp.OCEAN_address == "0x1234567890123456789012345678901234567890"
-

--- a/pdr_backend/ppss/test/test_web3_pp.py
+++ b/pdr_backend/ppss/test/test_web3_pp.py
@@ -5,7 +5,6 @@ import pytest
 from enforce_typing import enforce_types
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
-from pdr_backend.util.constants import ZERO_ADDRESS
 from pdr_backend.ppss.ppss import mock_feed_ppss
 
 from pdr_backend.contract.predictoor_contract import mock_predictoor_contract
@@ -212,7 +211,7 @@ def test_get_addresses():
     # Work 1: validate network can't be found
     with patch.object(web3_pp, "get_addresses", return_value=None):
         with pytest.raises(ValueError) as excinfo:
-            web3_pp.OCEAN_address
+            web3_pp.OCEAN_address  # pylint: disable=pointless-statement
 
     assert 'Cannot find network "development"' in str(excinfo.value)
 

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -1,24 +1,24 @@
-import random
-import os
 import json
+import os
+import random
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from unittest.mock import Mock
 
+import addresses
 from enforce_typing import enforce_types
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
 
 from pdr_backend.cli.arg_feeds import ArgFeeds
 from pdr_backend.contract.slot import Slot
+from pdr_backend.contract.token import NativeToken, Token
 from pdr_backend.subgraph.subgraph_feed import SubgraphFeed
 from pdr_backend.subgraph.subgraph_feed_contracts import query_feed_contracts
 from pdr_backend.subgraph.subgraph_pending_slots import get_pending_slots
-from pdr_backend.util.strutil import StrMixin
 from pdr_backend.util.contract import _condition_sapphire_keys
+from pdr_backend.util.strutil import StrMixin
 from pdr_backend.util.web3_config import Web3Config
-import addresses
-from pdr_backend.contract.token import Token, NativeToken
 
 
 class Web3PP(StrMixin):

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -18,7 +18,7 @@ from pdr_backend.util.strutil import StrMixin
 from pdr_backend.util.contract import _condition_sapphire_keys
 from pdr_backend.util.web3_config import Web3Config
 import addresses
-from pdr_backend.contract.token import Token
+from pdr_backend.contract.token import Token, NativeToken
 
 
 class Web3PP(StrMixin):
@@ -222,6 +222,10 @@ class Web3PP(StrMixin):
     @property
     def OCEAN_Token(self) -> str:
         return Token(self, self.OCEAN_address)
+
+    @property
+    def NativeToken(self) -> str:
+        return NativeToken(self)
 
 
 # =========================================================================

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -21,6 +21,7 @@ from pdr_backend.util.strutil import StrMixin
 from pdr_backend.util.web3_config import Web3Config
 
 
+# pylint: disable=too-many-public-methods
 class Web3PP(StrMixin):
     __STR_OBJDIR__ = ["network", "d"]
 

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -16,7 +16,7 @@ from pdr_backend.contract.token import NativeToken, Token
 from pdr_backend.subgraph.subgraph_feed import SubgraphFeed
 from pdr_backend.subgraph.subgraph_feed_contracts import query_feed_contracts
 from pdr_backend.subgraph.subgraph_pending_slots import get_pending_slots
-from pdr_backend.util.contract import _condition_sapphire_keys
+from pdr_backend.util.contract import _condition_sapphire_keys, get_contract_filename
 from pdr_backend.util.strutil import StrMixin
 from pdr_backend.util.web3_config import Web3Config
 
@@ -229,6 +229,19 @@ class Web3PP(StrMixin):
 
     def get_token_balance(self, address):
         return self.web3_config.w3.eth.get_balance(address)
+
+    def get_contract_abi(self, contract_name: str):
+        """
+        Returns the ABI for the specified contract
+        """
+        path = get_contract_filename(contract_name, self.address_file)
+
+        if not path.exists():
+            raise TypeError("Contract name does not exist in artifacts.")
+
+        with open(path) as f:
+            data = json.load(f)
+            return data["abi"]
 
 
 # =========================================================================

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -220,11 +220,11 @@ class Web3PP(StrMixin):
         return self.get_address("Ocean")
 
     @property
-    def OCEAN_Token(self) -> str:
+    def OCEAN_Token(self) -> Token:
         return Token(self, self.OCEAN_address)
 
     @property
-    def NativeToken(self) -> str:
+    def NativeToken(self) -> NativeToken:
         return NativeToken(self)
 
 

--- a/pdr_backend/ppss/web3_pp.py
+++ b/pdr_backend/ppss/web3_pp.py
@@ -227,6 +227,9 @@ class Web3PP(StrMixin):
     def NativeToken(self) -> NativeToken:
         return NativeToken(self)
 
+    def get_token_balance(self, address):
+        return self.web3_config.w3.eth.get_balance(address)
+
 
 # =========================================================================
 # utilities for testing

--- a/pdr_backend/publisher/publish_asset.py
+++ b/pdr_backend/publisher/publish_asset.py
@@ -5,7 +5,6 @@ from enforce_typing import enforce_types
 from pdr_backend.contract.data_nft import DataNft
 from pdr_backend.contract.erc721_factory import Erc721Factory
 from pdr_backend.ppss.web3_pp import Web3PP
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import to_wei
 
 MAX_UINT256 = 2**256 - 1
@@ -30,8 +29,8 @@ def publish_asset(
     pair = base + "/" + quote
     trueval_timeout = 60 * 60 * 24 * 3
     owner = web3_config.owner
-    ocean_address = get_address(web3_pp, "Ocean")
-    fre_address = get_address(web3_pp, "FixedPrice")
+    ocean_address = web3_pp.OCEAN_address
+    fre_address = web3_pp.get_address("FixedPrice")
     factory = Erc721Factory(web3_pp)
 
     feeCollector = web3_config.w3.to_checksum_address(feeCollector_addr)

--- a/pdr_backend/publisher/publish_assets.py
+++ b/pdr_backend/publisher/publish_assets.py
@@ -3,7 +3,6 @@ from enforce_typing import enforce_types
 from pdr_backend.ppss.publisher_ss import PublisherSS
 from pdr_backend.ppss.web3_pp import Web3PP
 from pdr_backend.publisher.publish_asset import publish_asset
-from pdr_backend.util.contract import get_address
 
 _CUT = 0.2
 _RATE = 3 / (1 + _CUT + 0.001)  # token price
@@ -22,7 +21,7 @@ def publish_assets(web3_pp: Web3PP, publisher_ss: PublisherSS):
         trueval_submitter_addr = "0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"
         fee_collector_addr = "0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"
     elif "sapphire" in web3_pp.network:
-        trueval_submitter_addr = get_address(web3_pp, "PredictoorHelper")
+        trueval_submitter_addr = web3_pp.get_address("PredictoorHelper")
         fee_collector_addr = publisher_ss.fee_collector_address
     else:
         raise ValueError(web3_pp.network)

--- a/pdr_backend/publisher/test/test_publish_asset.py
+++ b/pdr_backend/publisher/test/test_publish_asset.py
@@ -3,7 +3,6 @@ from pytest import approx
 
 from pdr_backend.contract.predictoor_contract import PredictoorContract
 from pdr_backend.publisher.publish_asset import publish_asset
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
@@ -43,7 +42,6 @@ def test_publish_asset(web3_pp, web3_config):
     )
     assert contract.get_price() / 1e18 == approx(3 * (1.201))
 
-    ocean_address = get_address(web3_pp, "Ocean")
-    assert contract.get_stake_token() == ocean_address
+    assert contract.get_stake_token() == web3_pp.OCEAN_address
 
     assert contract.get_trueValSubmitTimeout() == 3 * 24 * 60 * 60

--- a/pdr_backend/publisher/test/test_publish_assets.py
+++ b/pdr_backend/publisher/test/test_publish_assets.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from enforce_typing import enforce_types
 
 from pdr_backend.ppss.publisher_ss import mock_publisher_ss
-from pdr_backend.ppss.web3_pp import mock_web3_pp
+from pdr_backend.ppss.web3_pp import mock_web3_pp, Web3PP
 from pdr_backend.publisher.publish_assets import publish_assets
 
 _PATH = "pdr_backend.publisher.publish_assets"
@@ -60,10 +60,9 @@ def _test_sapphire(network, monkeypatch):
 
 
 def _setup_and_publish(network, monkeypatch):
-    web3_pp = mock_web3_pp(network)
+    web3_pp = Mock(spec=Web3PP)
+    web3_pp.network = "development"
     publisher_ss = mock_publisher_ss(network)
-
-    monkeypatch.setattr(f"{_PATH}.get_address", Mock())
 
     mock_publish_asset = Mock()
     monkeypatch.setattr(f"{_PATH}.publish_asset", mock_publish_asset)

--- a/pdr_backend/publisher/test/test_publish_assets.py
+++ b/pdr_backend/publisher/test/test_publish_assets.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from enforce_typing import enforce_types
 
 from pdr_backend.ppss.publisher_ss import mock_publisher_ss
-from pdr_backend.ppss.web3_pp import mock_web3_pp, Web3PP
+from pdr_backend.ppss.web3_pp import Web3PP
 from pdr_backend.publisher.publish_assets import publish_assets
 
 _PATH = "pdr_backend.publisher.publish_assets"

--- a/pdr_backend/util/contract.py
+++ b/pdr_backend/util/contract.py
@@ -4,63 +4,11 @@ import os
 from pathlib import Path
 from typing import Union
 
-import addresses
 import artifacts
 from enforce_typing import enforce_types
 
 
-@enforce_types
-def get_address(web3_pp, contract_name: str):
-    """
-    Returns address for this contract
-    in web3_pp.address_file, in web3_pp.network
-    """
-    network = get_addresses(web3_pp)
-    if not network:
-        raise ValueError(f'Cannot find network "{web3_pp.network}" in addresses.json')
-
-    address = network.get(contract_name)
-    if not address:
-        error = (
-            f'Cannot find contract "{contract_name}" in address.json '
-            f'for network "{web3_pp.network}"'
-        )
-        raise ValueError(error)
-
-    return address
-
-
-@enforce_types
-def get_addresses(web3_pp) -> Union[dict, None]:
-    """
-    Returns addresses in web3_pp.address_file, in web3_pp.network
-    """
-    address_file = web3_pp.address_file
-
-    path = None
-    if address_file:
-        address_file = os.path.expanduser(address_file)
-        path = Path(address_file)
-    else:
-        path = Path(str(os.path.dirname(addresses.__file__)) + "/address.json")
-
-    if not path.exists():
-        raise TypeError(f"Cannot find address.json file at {path}")
-
-    with open(path) as f:
-        d = json.load(f)
-
-    d = _condition_sapphire_keys(d)
-
-    if "barge" in web3_pp.network:  # eg "barge-pytest"
-        return d["development"]
-
-    if web3_pp.network in d:  # eg "development", "oasis_sapphire"
-        return d[web3_pp.network]
-
-    return None
-
-
+# TODO: I think some of these others functions warrant being moved to web3_pp.py
 @enforce_types
 def get_contract_abi(contract_name: str, address_file: Union[str, None]):
     """Returns the abi dict for a contract name."""

--- a/pdr_backend/util/contract.py
+++ b/pdr_backend/util/contract.py
@@ -1,25 +1,10 @@
 import copy
-import json
 import os
 from pathlib import Path
 from typing import Union
 
 import artifacts
 from enforce_typing import enforce_types
-
-
-# TODO: I think some of these others functions warrant being moved to web3_pp.py
-@enforce_types
-def get_contract_abi(contract_name: str, address_file: Union[str, None]):
-    """Returns the abi dict for a contract name."""
-    path = get_contract_filename(contract_name, address_file)
-
-    if not path.exists():
-        raise TypeError("Contract name does not exist in artifacts.")
-
-    with open(path) as f:
-        data = json.load(f)
-        return data["abi"]
 
 
 @enforce_types

--- a/pdr_backend/util/core_accounts.py
+++ b/pdr_backend/util/core_accounts.py
@@ -6,7 +6,6 @@ from eth_account import Account
 
 from pdr_backend.contract.token import Token
 from pdr_backend.ppss.web3_pp import Web3PP
-from pdr_backend.util.contract import get_address
 
 
 @enforce_types
@@ -27,8 +26,7 @@ def fund_accounts_with_OCEAN(web3_pp: Web3PP):
         ("PDR_MM_USER", 10000.0),
     ]
 
-    OCEAN_addr = get_address(web3_pp, "Ocean")
-    OCEAN = Token(web3_pp, OCEAN_addr)
+    OCEAN = web3_pp.OCEAN_Token
     _fund_accounts(accounts_to_fund, web3_pp.web3_config.owner, OCEAN)
     print("Done funding.")
 

--- a/pdr_backend/util/test_ganache/test_core_accounts.py
+++ b/pdr_backend/util/test_ganache/test_core_accounts.py
@@ -5,7 +5,7 @@ from enforce_typing import enforce_types
 from eth_account import Account
 
 from pdr_backend.contract.token import Token
-from pdr_backend.ppss.web3_pp import mock_web3_pp
+from pdr_backend.ppss.web3_pp import Web3PP
 from pdr_backend.util.core_accounts import _fund_accounts, fund_accounts_with_OCEAN
 
 
@@ -14,13 +14,13 @@ def test_fund_accounts_with_OCEAN(monkeypatch):
     if os.getenv("NETWORK_OVERRIDE"):
         monkeypatch.delenv("NETWORK_OVERRIDE")
 
-    web3_pp = mock_web3_pp("development")
+    web3_pp = Mock(spec=Web3PP)
+    web3_pp.network = "development"
+    web3_pp.OCEAN_Token = Mock(spec=Token)
+    web3_pp.web3_config = Mock()
+    web3_pp.web3_config.owner = "0x123"
 
     path = "pdr_backend.util.core_accounts"
-
-    monkeypatch.setattr(f"{path}.get_address", Mock())
-    monkeypatch.setattr(f"{path}.Token", Mock())
-
     mock_f = Mock()
     monkeypatch.setattr(f"{path}._fund_accounts", mock_f)
 

--- a/pdr_backend/util/test_ganache/test_web3_accounts.py
+++ b/pdr_backend/util/test_ganache/test_web3_accounts.py
@@ -16,9 +16,9 @@ def test_create_accounts(mock_create):
 
 
 @enforce_types
-@patch("pdr_backend.util.web3_accounts.Token")
+@patch("pdr_backend.ppss.web3_pp.Token")
 @patch("pdr_backend.util.web3_accounts.NativeToken")
-@patch("pdr_backend.util.web3_accounts.get_address")
+@patch("pdr_backend.ppss.web3_pp.Web3PP.get_address")
 def test_get_account_balances(mock_get_address, mock_native_token, mock_token):
     web3_pp = mock_web3_pp("development")
 
@@ -48,9 +48,9 @@ def test_get_account_balances(mock_get_address, mock_native_token, mock_token):
 
 @enforce_types
 @patch("eth_account.Account.from_key")
-@patch("pdr_backend.util.web3_accounts.Token")
+@patch("pdr_backend.ppss.web3_pp.Token")
 @patch("pdr_backend.util.web3_accounts.NativeToken")
-@patch("pdr_backend.util.web3_accounts.get_address")
+@patch("pdr_backend.ppss.web3_pp.Web3PP.get_address")
 def test_fund_accounts(
     mock_get_address, mock_native_token, mock_token, mock_account_from_key
 ):

--- a/pdr_backend/util/test_ganache/test_web3_accounts.py
+++ b/pdr_backend/util/test_ganache/test_web3_accounts.py
@@ -17,7 +17,7 @@ def test_create_accounts(mock_create):
 
 @enforce_types
 @patch("pdr_backend.ppss.web3_pp.Token")
-@patch("pdr_backend.util.web3_accounts.NativeToken")
+@patch("pdr_backend.ppss.web3_pp.NativeToken")
 @patch("pdr_backend.ppss.web3_pp.Web3PP.get_address")
 def test_get_account_balances(mock_get_address, mock_native_token, mock_token):
     web3_pp = mock_web3_pp("development")
@@ -49,7 +49,7 @@ def test_get_account_balances(mock_get_address, mock_native_token, mock_token):
 @enforce_types
 @patch("eth_account.Account.from_key")
 @patch("pdr_backend.ppss.web3_pp.Token")
-@patch("pdr_backend.util.web3_accounts.NativeToken")
+@patch("pdr_backend.ppss.web3_pp.NativeToken")
 @patch("pdr_backend.ppss.web3_pp.Web3PP.get_address")
 def test_fund_accounts(
     mock_get_address, mock_native_token, mock_token, mock_account_from_key

--- a/pdr_backend/util/test_noganache/test_contract.py
+++ b/pdr_backend/util/test_noganache/test_contract.py
@@ -1,14 +1,11 @@
 from pathlib import Path
 
-from unittest.mock import patch
 import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.util.contract import (
     _condition_sapphire_keys,
-    get_address,
-    get_addresses,
     get_contract_abi,
     get_contract_filename,
 )
@@ -29,11 +26,6 @@ def test_contract_main(network):
     web3_pp = ppss.web3_pp
     assert web3_pp.network == network
 
-    # tests
-    assert get_address(web3_pp, "Ocean") is not None
-
-    assert get_addresses(web3_pp) is not None
-
     result = get_contract_abi("ERC20Template3", web3_pp.address_file)
     assert len(result) > 0 and isinstance(result, list)
 
@@ -42,34 +34,6 @@ def test_contract_main(network):
 
     with pytest.raises(TypeError):
         get_contract_abi("xyz", web3_pp.address_file)
-
-
-@enforce_types
-@patch("pdr_backend.util.contract.get_addresses")
-def test_get_addresses(mock_get_addresses):
-    # setup
-    network = "development"
-    ppss = mock_ppss(["binance BTC/USDT c 5m"], network)
-    web3_pp = ppss.web3_pp
-    assert web3_pp.network == network
-
-    mock_get_addresses.return_value = None
-
-    # Work 1: validate network can't be found
-    with pytest.raises(ValueError) as excinfo:
-        get_address(web3_pp, "Ocean")
-
-    assert 'Cannot find network "development"' in str(excinfo.value)
-
-    mock_get_addresses.return_value = {
-        "Ocean": "0x1234567890123456789012345678901234567890"
-    }
-    with pytest.raises(ValueError) as excinfo:
-        get_address(web3_pp, "ERCUnknown")
-
-    assert 'Cannot find contract "ERCUnknown"' in str(excinfo.value)
-
-    assert get_address(web3_pp, "Ocean") == "0x1234567890123456789012345678901234567890"
 
 
 @enforce_types

--- a/pdr_backend/util/test_noganache/test_contract.py
+++ b/pdr_backend/util/test_noganache/test_contract.py
@@ -6,7 +6,6 @@ from enforce_typing import enforce_types
 from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.util.contract import (
     _condition_sapphire_keys,
-    get_contract_abi,
     get_contract_filename,
 )
 
@@ -26,14 +25,14 @@ def test_contract_main(network):
     web3_pp = ppss.web3_pp
     assert web3_pp.network == network
 
-    result = get_contract_abi("ERC20Template3", web3_pp.address_file)
+    result = web3_pp.get_contract_abi("ERC20Template3")
     assert len(result) > 0 and isinstance(result, list)
 
     result = get_contract_filename("ERC20Template3", web3_pp.address_file)
     assert result is not None and isinstance(result, Path)
 
     with pytest.raises(TypeError):
-        get_contract_abi("xyz", web3_pp.address_file)
+        web3_pp.get_contract_abi("xyz")
 
 
 @enforce_types

--- a/pdr_backend/util/test_noganache/test_topup.py
+++ b/pdr_backend/util/test_noganache/test_topup.py
@@ -5,6 +5,7 @@ from enforce_typing import enforce_types
 
 from pdr_backend.contract.token import NativeToken, Token
 from pdr_backend.ppss.ppss import mock_ppss
+from pdr_backend.ppss.web3_pp import Web3PP
 from pdr_backend.util.mathutil import to_wei
 from pdr_backend.util.topup import topup_main
 
@@ -52,8 +53,6 @@ def mock_get_opf_addresses():
 @enforce_types
 def test_topup_main(mock_token_, mock_native_token_, mock_get_opf_addresses_, tmpdir):
     ppss = mock_ppss(["binance BTC/USDT c 5m"], "sapphire-mainnet", str(tmpdir))
-
-    from pdr_backend.ppss.web3_pp import Web3PP
 
     mock_web3_pp = MagicMock(spec=Web3PP)
     mock_web3_pp.network = "sapphire-testnet"

--- a/pdr_backend/util/test_noganache/test_topup.py
+++ b/pdr_backend/util/test_noganache/test_topup.py
@@ -12,7 +12,14 @@ from pdr_backend.util.topup import topup_main
 @pytest.fixture(name="mock_token_")
 def mock_token():
     token = MagicMock(spec=Token)
-    token.balanceOf.side_effect = [to_wei(500), 0, 0]  # Mock balance in wei
+    token.balanceOf.side_effect = [
+        to_wei(500),
+        to_wei(500),
+        0,
+        0,
+        0,
+        0,
+    ]  # Mock balance in wei
     token.transfer.return_value = None
     return token
 
@@ -20,7 +27,14 @@ def mock_token():
 @pytest.fixture(name="mock_native_token_")
 def mock_native_token():
     native_token = MagicMock(spec=NativeToken)
-    native_token.balanceOf.side_effect = [to_wei(500), 0, 0]  # Mock balance in wei
+    native_token.balanceOf.side_effect = [
+        to_wei(500),
+        to_wei(500),
+        0,
+        0,
+        0,
+        0,
+    ]  # Mock balance in wei
     native_token.transfer.return_value = None
     return native_token
 
@@ -39,10 +53,17 @@ def mock_get_opf_addresses():
 def test_topup_main(mock_token_, mock_native_token_, mock_get_opf_addresses_, tmpdir):
     ppss = mock_ppss(["binance BTC/USDT c 5m"], "sapphire-mainnet", str(tmpdir))
 
+    from pdr_backend.ppss.web3_pp import Web3PP
+
+    mock_web3_pp = MagicMock(spec=Web3PP)
+    mock_web3_pp.network = "sapphire-testnet"
+    mock_web3_pp.OCEAN_Token = mock_token_
+    mock_web3_pp.NativeToken = mock_native_token_
+
+    ppss.web3_pp = mock_web3_pp
+
     PATH = "pdr_backend.util.topup"
-    with patch(f"{PATH}.Token", return_value=mock_token_), patch(
-        f"{PATH}.NativeToken", return_value=mock_native_token_
-    ), patch(f"{PATH}.get_opf_addresses", mock_get_opf_addresses_), patch(
+    with patch(f"{PATH}.get_opf_addresses", mock_get_opf_addresses_), patch(
         f"{PATH}.sys.exit"
     ) as mock_exit:
         topup_main(ppss)
@@ -51,7 +72,3 @@ def test_topup_main(mock_token_, mock_native_token_, mock_get_opf_addresses_, tm
 
         assert mock_token_.transfer.called
         assert mock_native_token_.transfer.called
-
-    ppss.web3_pp.network = "foo"
-    with pytest.raises(SystemExit):
-        topup_main(ppss)

--- a/pdr_backend/util/topup.py
+++ b/pdr_backend/util/topup.py
@@ -3,10 +3,9 @@ from typing import Dict
 
 from enforce_typing import enforce_types
 
-from pdr_backend.contract.token import NativeToken, Token
+from pdr_backend.contract.token import NativeToken
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.util.constants_opf_addrs import get_opf_addresses
-from pdr_backend.util.contract import get_address
 from pdr_backend.util.mathutil import from_wei, to_wei
 
 
@@ -17,12 +16,7 @@ def topup_main(ppss: PPSS):
 
     web3_pp = ppss.web3_pp
     owner = web3_pp.web3_config.owner
-    if web3_pp.network not in ["sapphire-testnet", "sapphire-mainnet"]:
-        print("Unknown network")
-        sys.exit(1)
-
-    OCEAN_addr = get_address(ppss.web3_pp, "Ocean")
-    OCEAN = Token(ppss.web3_pp, OCEAN_addr)
+    OCEAN = web3_pp.OCEAN_Token
     ROSE = NativeToken(ppss.web3_pp)
 
     owner_OCEAN_bal = from_wei(OCEAN.balanceOf(owner))

--- a/pdr_backend/util/topup.py
+++ b/pdr_backend/util/topup.py
@@ -17,7 +17,7 @@ def topup_main(ppss: PPSS):
     web3_pp = ppss.web3_pp
     owner = web3_pp.web3_config.owner
     OCEAN = web3_pp.OCEAN_Token
-    ROSE = NativeToken(ppss.web3_pp)
+    ROSE = web3_pp.NativeToken
 
     owner_OCEAN_bal = from_wei(OCEAN.balanceOf(owner))
     owner_ROSE_bal = from_wei(ROSE.balanceOf(owner))

--- a/pdr_backend/util/topup.py
+++ b/pdr_backend/util/topup.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 from enforce_typing import enforce_types
 
-from pdr_backend.contract.token import NativeToken
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.util.constants_opf_addrs import get_opf_addresses
 from pdr_backend.util.mathutil import from_wei, to_wei

--- a/pdr_backend/util/web3_accounts.py
+++ b/pdr_backend/util/web3_accounts.py
@@ -5,8 +5,7 @@ from enforce_typing import enforce_types
 
 from eth_account import Account
 from pdr_backend.ppss.web3_pp import Web3PP
-from pdr_backend.contract.token import NativeToken, Token
-from pdr_backend.util.contract import get_address
+from pdr_backend.contract.token import NativeToken
 from pdr_backend.util.mathutil import to_wei, from_wei
 
 
@@ -33,8 +32,7 @@ def view_accounts(addresses: List[str], web3_pp: Web3PP):
     """
     # get assets
     native_token = NativeToken(web3_pp)
-    OCEAN_addr = get_address(web3_pp, "Ocean")
-    OCEAN_token = Token(web3_pp, OCEAN_addr)
+    OCEAN_token = web3_pp.OCEAN_Token
 
     # loop through all addresses and print balances
     for address in addresses:
@@ -66,8 +64,7 @@ def fund_accounts(
     if is_native_token:
         token = NativeToken(web3_pp)
     else:
-        OCEAN_addr = get_address(web3_pp, "Ocean")
-        token = Token(web3_pp, OCEAN_addr)
+        token = web3_pp.OCEAN_Token
 
     account = Account.from_key(private_key)  # pylint: disable=no-value-for-parameter
 

--- a/pdr_backend/util/web3_accounts.py
+++ b/pdr_backend/util/web3_accounts.py
@@ -59,11 +59,10 @@ def fund_accounts(
         print(f"Unknown network {web3_pp.network}")
         sys.exit(1)
 
-    token = None
-    if is_native_token:
-        token = web3_pp.NativeToken
-    else:
-        token = web3_pp.OCEAN_Token
+    token = web3_pp.NativeToken if is_native_token else web3_pp.OCEAN_Token
+
+    assert hasattr(token, "name")
+    assert hasattr(token, "transfer")
 
     account = Account.from_key(private_key)  # pylint: disable=no-value-for-parameter
 

--- a/pdr_backend/util/web3_accounts.py
+++ b/pdr_backend/util/web3_accounts.py
@@ -5,7 +5,6 @@ from enforce_typing import enforce_types
 
 from eth_account import Account
 from pdr_backend.ppss.web3_pp import Web3PP
-from pdr_backend.contract.token import NativeToken
 from pdr_backend.util.mathutil import to_wei, from_wei
 
 
@@ -31,7 +30,7 @@ def view_accounts(addresses: List[str], web3_pp: Web3PP):
         View account balances for multiple addresses
     """
     # get assets
-    native_token = NativeToken(web3_pp)
+    native_token = web3_pp.NativeToken
     OCEAN_token = web3_pp.OCEAN_Token
 
     # loop through all addresses and print balances
@@ -62,7 +61,7 @@ def fund_accounts(
 
     token = None
     if is_native_token:
-        token = NativeToken(web3_pp)
+        token = web3_pp.NativeToken
     else:
         token = web3_pp.OCEAN_Token
 

--- a/system_tests/test_check_network_system.py
+++ b/system_tests/test_check_network_system.py
@@ -10,7 +10,7 @@ from pdr_backend.util.web3_config import Web3Config
 
 @patch("pdr_backend.analytics.check_network.print_stats")
 @patch("pdr_backend.analytics.check_network.check_dfbuyer")
-def test_topup(mock_print_stats, mock_check_dfbuyer):
+def test_check_network(mock_print_stats, mock_check_dfbuyer):
     mock_web3_pp = MagicMock(spec=Web3PP)
     mock_web3_pp.network = "sapphire-mainnet"
     mock_web3_pp.subgraph_url = (
@@ -27,6 +27,9 @@ def test_topup(mock_print_stats, mock_check_dfbuyer):
     mock_token.balanceOf.return_value = int(5e18)
     mock_token.transfer.return_value = True
 
+    mock_web3_pp.OCEAN_Token = mock_token
+    mock_web3_pp.NativeToken = mock_token
+
     mock_query_subgraph = Mock()
     mock_query_subgraph.return_value = {
         "data": {
@@ -37,17 +40,9 @@ def test_topup(mock_print_stats, mock_check_dfbuyer):
             ]
         }
     }
-    with patch("pdr_backend.contract.token.Token", return_value=mock_token), patch(
-        "pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp
-    ), patch(
-        "pdr_backend.analytics.check_network.Token", return_value=mock_token
-    ), patch(
-        "pdr_backend.analytics.check_network.get_address", return_value="0x1"
-    ), patch(
+    with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
         "sys.exit"
-    ), patch(
-        "pdr_backend.analytics.check_network.query_subgraph", mock_query_subgraph
-    ):
+    ), patch("pdr_backend.analytics.check_network.query_subgraph", mock_query_subgraph):
         # Mock sys.argv
         sys.argv = ["pdr", "check_network", "ppss.yaml", "development"]
 

--- a/system_tests/test_check_network_system.py
+++ b/system_tests/test_check_network_system.py
@@ -19,7 +19,6 @@ def test_check_network(mock_print_stats, mock_check_dfbuyer):
 
     mock_web3_config = Mock(spec=Web3Config)
     mock_web3_config.w3 = Mock()
-    mock_web3_config.w3.eth.get_balance.return_value = 100
     mock_web3_pp.web3_config = mock_web3_config
     mock_web3_pp.web3_config.owner = "0xowner"
 
@@ -29,6 +28,7 @@ def test_check_network(mock_print_stats, mock_check_dfbuyer):
 
     mock_web3_pp.OCEAN_Token = mock_token
     mock_web3_pp.NativeToken = mock_token
+    mock_web3_pp.get_token_balance.return_value = 100
 
     mock_query_subgraph = Mock()
     mock_query_subgraph.return_value = {

--- a/system_tests/test_dfbuyer_agent_system.py
+++ b/system_tests/test_dfbuyer_agent_system.py
@@ -60,12 +60,8 @@ def test_dfbuyer_agent(mock_wait_until_subgraph_syncs, mock_time_sleep):
     }
 
     with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
-        "pdr_backend.cli.cli_module.get_address", return_value="0x1"
-    ), patch("pdr_backend.dfbuyer.dfbuyer_agent.Token", return_value=mock_token), patch(
         "pdr_backend.dfbuyer.dfbuyer_agent.PredictoorBatcher",
         return_value=mock_predictoor_batcher,
-    ), patch(
-        "pdr_backend.dfbuyer.dfbuyer_agent.get_address", return_value="0x1"
     ), patch(
         "pdr_backend.dfbuyer.dfbuyer_agent.get_consume_so_far_per_contract",
         mock_get_consume_so_far_per_contract,

--- a/system_tests/test_dfbuyer_agent_system.py
+++ b/system_tests/test_dfbuyer_agent_system.py
@@ -38,6 +38,9 @@ def test_dfbuyer_agent(mock_wait_until_subgraph_syncs, mock_time_sleep):
     mock_token.balanceOf.return_value = 100 * 1e18
     mock_token.allowance.return_value = 1e128
 
+    mock_web3_pp.get_address.return_value = "0x1"
+    mock_web3_pp.OCEAN_Token = mock_token
+
     mock_web3_config = Mock(spec=Web3Config)
     mock_web3_config.get_block.return_value = {"timestamp": 100}
     mock_web3_config.owner = "0x00000000000000000000000000000000000c0ffe"

--- a/system_tests/test_predictoor_system.py
+++ b/system_tests/test_predictoor_system.py
@@ -34,8 +34,6 @@ def _test_predictoor_system(mock_feeds, mock_predictoor_contract, approach):
     merged_ohlcv_df = Mock()
 
     with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
-        "pdr_backend.publisher.publish_assets.get_address", return_value="0x1"
-    ), patch(
         "pdr_backend.ppss.ppss.PredictoorSS", return_value=mock_predictoor_ss
     ), patch(
         "pdr_backend.lake.ohlcv_data_factory.OhlcvDataFactory.get_mergedohlcv_df",

--- a/system_tests/test_publisher_system.py
+++ b/system_tests/test_publisher_system.py
@@ -9,7 +9,7 @@ from pdr_backend.util.web3_config import Web3Config
 
 @patch("pdr_backend.cli.cli_module.fund_accounts_with_OCEAN")
 @patch("pdr_backend.publisher.publish_assets.publish_asset")
-def test_dfbuyer_agent(mock_fund_accounts, mock_publish_asset):
+def test_publisher(mock_fund_accounts, mock_publish_asset):
     mock_web3_pp = MagicMock(spec=Web3PP)
     mock_web3_pp.network = "development"
     mock_web3_pp.subgraph_url = (
@@ -20,9 +20,7 @@ def test_dfbuyer_agent(mock_fund_accounts, mock_publish_asset):
     mock_web3_config.w3 = Mock()
     mock_web3_pp.web3_config = mock_web3_config
 
-    with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
-        "pdr_backend.publisher.publish_assets.get_address", return_value="0x1"
-    ):
+    with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp):
         # Mock sys.argv
         sys.argv = ["pdr", "publisher", "ppss.yaml", "development"]
 

--- a/system_tests/test_topup_system.py
+++ b/system_tests/test_topup_system.py
@@ -25,13 +25,10 @@ def test_topup():
     mock_token.balanceOf.side_effect = balances_arr
     mock_token.transfer.return_value = True
 
-    with patch("pdr_backend.contract.token.Token", return_value=mock_token), patch(
-        "pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp
-    ), patch("pdr_backend.util.topup.Token", return_value=mock_token), patch(
-        "pdr_backend.util.topup.NativeToken", return_value=mock_token
-    ), patch(
-        "pdr_backend.util.topup.get_address", return_value="0x1"
-    ), patch(
+    mock_web3_pp.OCEAN_Token = mock_token
+    mock_web3_pp.NativeToken = mock_token
+
+    with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
         "sys.exit"
     ):
         # Mock sys.argv

--- a/system_tests/test_trueval_agent_system.py
+++ b/system_tests/test_trueval_agent_system.py
@@ -35,6 +35,7 @@ def test_trueval_batch(mock_wait_until_subgraph_syncs, mock_time_sleep, mock_pro
         )
     }
     mock_web3_pp.get_pending_slots.return_value = [Slot(1, feeds["0x1"])]
+    mock_web3_pp.get_address.return_value = "0x1"
 
     mock_web3_config = Mock(spec=Web3Config)
     mock_web3_config.get_block.return_value = {"timestamp": 100}
@@ -47,8 +48,6 @@ def test_trueval_batch(mock_wait_until_subgraph_syncs, mock_time_sleep, mock_pro
     mock_predictoor_batcher = Mock(spec=PredictoorBatcher)
 
     with patch("pdr_backend.ppss.ppss.Web3PP", return_value=mock_web3_pp), patch(
-        "pdr_backend.cli.cli_module.get_address", return_value="0x1"
-    ), patch(
         "pdr_backend.trueval.trueval_agent.PredictoorBatcher",
         return_value=mock_predictoor_batcher,
     ), patch(


### PR DESCRIPTION
Started from #412, move some contract utils into address to avoid duplication of token creation throughout the entire codebase