### PR TITLE
Replace cat facts with trivia questions

### DIFF
--- a/.github/workflows/check_mainnet.yml
+++ b/.github/workflows/check_mainnet.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           output=$(python pdr check_network ppss.yaml sapphire-mainnet | grep -E 'FAIL|WARNING|error' || true)
           
-          if [ -n "$output" ]; then
+          if [ -z "$output" ]; then
             echo "No output, so no message will be sent to Slack"
           else
             trivia_response=$(curl -s "https://opentdb.com/api.php?amount=1&difficulty=medium&type=multiple&category=18")


### PR DESCRIPTION
Changes proposed in this PR:

- Replace the cat facts posted on channel with tech trivia questions

Example
```
Mainnet Check script failed: 

Trivia question: What is the number of keys on a standard Windows Keyboard?
Options:
A: 76
B: 94
C: 64
D: 104
```