### PR TITLE
#651 - Partitioned Data Store

### DIFF
--- a/pdr_backend/lake/base_data_store.py
+++ b/pdr_backend/lake/base_data_store.py
@@ -1,0 +1,43 @@
+from hashlib import md5
+from abc import abstractmethod
+from typing import Optional, Literal
+
+import duckdb
+from enforce_typing import enforce_types
+
+
+class BaseDataStore:
+    @enforce_types
+    def __init__(self, base_directory=str):
+        """
+        Initialize a PartitionedDataStore instance.
+        @arguments:
+            base_directory - The base directory to store the partitioned Parquet files.
+        """
+
+        self.base_directory = base_directory
+        self.duckdb_conn = duckdb.connect(
+            database=f"{self.base_directory}/duckdb.db"
+        )  # Keep a persistent connection
+
+    @enforce_types
+    def _generate_view_name(self, base_path=str) -> str:
+        """
+        Generate a unique view name for a given base path.
+        @arguments:
+            base_path - The base path to generate a view name for.
+        @returns:
+            str - A unique view name.
+        """
+
+        hash_object = md5(base_path.encode())
+        return f"dataset_{hash_object.hexdigest()}"
+
+    @abstractmethod
+    def query_data(
+        self,
+        dataset_identifier: str,
+        query: str,
+        partition_type: Optional[Literal["date", "address"]] = None,
+    ):
+        pass

--- a/pdr_backend/lake/partitioned_data_store.py
+++ b/pdr_backend/lake/partitioned_data_store.py
@@ -1,0 +1,257 @@
+from typing import Optional
+
+import os
+import polars as pl
+
+from enforce_typing import enforce_types
+from pdr_backend.lake.base_data_store import BaseDataStore
+
+# Maybe a base class
+# PersistentDataStore (it will include only DuckDB)
+# PartitionedDataStore (it will handle everything related to partitioned data *.parquet files)
+
+
+class PartitionedDataStore(BaseDataStore):
+    """
+    A class to manage partitioned Parquet files using DuckDB.
+    """
+
+    @enforce_types
+    def __init__(self, base_directory=str):
+        """
+        Initialize a PartitionedDataStore instance.
+        @arguments:
+            base_directory - The base directory to store the partitioned Parquet files.
+        """
+
+        super().__init__(base_directory)
+
+        self.partition_patterns = {
+            "date": "/year=*/month=*/day=*/*.parquet",
+            "address": "/address=*/*.parquet",
+        }
+
+    @enforce_types
+    def create_view_and_query_data(
+        self, dataset_identifier: str, query: str
+    ) -> pl.DataFrame:
+        """
+        Avoid to use it if it is not necessary. It is better to use the query_data method.
+        Execute a SQL query across partitioned Parquet files using DuckDB.
+        @arguments:
+            dataset_identifier - A unique identifier for the dataset.
+            query - The SQL query to execute. The query must contain a {view_name} placeholder.
+
+        @returns:
+            pl.DataFrame - The result of the query.
+
+        @example:
+            create_view_and_query_data(
+                "transactions",
+                "SELECT * FROM {view_name} WHERE value > 1000"
+            )
+        """
+
+        dataset_path = os.path.join(self.base_directory, dataset_identifier)
+        view_name = self._generate_view_name(dataset_path)
+
+        # check if the query is valid
+        if "{view_name}" not in query:
+            raise ValueError("query must contain a {view_name} placeholder")
+
+        temp_view_name = f"temp_{view_name}"
+        # DuckDB automatically recognizes the partition scheme when reading from a directory
+        self.duckdb_conn.execute(
+            f"""CREATE OR REPLACE VIEW {temp_view_name} AS 
+            SELECT * FROM read_parquet(
+                '{dataset_path}{self.partition_patterns["date"]}', 
+                hive_partitioning=1
+            )"""
+        )
+
+        # Execute the provided SQL query
+        result_df = self.duckdb_conn.execute(
+            query.format(view_name=temp_view_name)
+        ).df()
+
+        # DROP the view to free up memory / disk space
+        self.duckdb_conn.execute(f"DROP VIEW {temp_view_name}")
+
+        return pl.DataFrame(result_df)
+
+    @enforce_types
+    def query_data(
+        self,
+        dataset_identifier: str,
+        query: str,
+        partition_type: Optional[str] = "date",
+    ) -> pl.DataFrame:
+        """
+        Execute a SQL query directly on partitioned Parquet files using DuckDB.
+            @arguments:
+                dataset_identifier - A unique identifier for the dataset.
+                query - The SQL query to execute.
+                    The query must contain a {dataset_path} placeholder.
+
+            @returns:
+                pl.DataFrame - The result of the query.
+
+            @example:
+                query_data(
+                    "transactions",
+                    "SELECT * FROM {dataset_path} WHERE value > 1000",
+                    "date"
+                )
+        """
+        if partition_type not in ["date", "address"]:
+            raise ValueError("partition_type must be either 'date' or 'address'")
+
+        # check if the query is valid
+        if "{dataset_path}" not in query:
+            raise ValueError("query must contain a {dataset_path} placeholder")
+
+        dataset_path = os.path.join(self.base_directory, dataset_identifier)
+
+        # DuckDB automatically recognizes the partition scheme when reading from a directory
+        result_df = self.duckdb_conn.execute(
+            query.format(
+                dataset_path=f"""
+                         read_parquet(
+                            '{dataset_path}{self.partition_patterns[partition_type]}', 
+                            hive_partitioning=1
+                         )"""
+            )
+        ).df()
+
+        return pl.DataFrame(result_df)
+
+    @enforce_types
+    def _export_data_with_address_hive(
+        self, dataset_identifier: str, address_column: str
+    ):
+        """
+        Finalizes the data by writing the persistent dataset to partitioned
+        Parquet files using the COPY command.
+        The data is partitioned by the Ethereum address.
+        @arguments:
+            dataset_identifier - A unique identifier for the dataset.
+            address_column - The name of the column containing the Ethereum addresses.
+        """
+
+        view_name = self._generate_view_name(self.base_directory + dataset_identifier)
+
+        self.duckdb_conn.execute(
+            f"""CREATE OR REPLACE VIEW processed_data AS 
+            SELECT *, {address_column} FROM {view_name}"""
+        )
+
+        dataset_path = os.path.join(self.base_directory, dataset_identifier)
+
+        if not os.path.exists(dataset_path):
+            # Create the directory if it doesn't exist
+            os.makedirs(dataset_path)
+
+        copy_query = f"""
+            COPY (
+                SELECT * FROM processed_data
+            )
+            TO '{dataset_path}'
+            (
+                FORMAT PARQUET,
+                PARTITION_BY ({address_column}),
+                OVERWRITE_OR_IGNORE 1
+            )"""
+
+        # Use the COPY command to write the data to the partitioned Parquet files
+        self.duckdb_conn.execute(copy_query)
+
+        # DROP the view to free up memory / disk space
+        self.duckdb_conn.execute("DROP VIEW processed_data")
+
+    @enforce_types
+    def _export_data_with_date_hive(
+        self, dataset_identifier: str, date_column: str = "timestamp"
+    ):
+        """
+        Finalizes the data by writing the persistent dataset to
+        partitioned Parquet files using the COPY command.
+        @arguments:
+            dataset_identifier - A unique identifier for the dataset.
+        """
+
+        print("dataset_identifier", dataset_identifier)
+        view_name = self._generate_view_name(self.base_directory + dataset_identifier)
+
+        self.duckdb_conn.execute(
+            f"""CREATE OR REPLACE VIEW processed_data AS 
+            SELECT *, 
+                DATE_PART('year', CAST({date_column} AS TIMESTAMP)) as year,
+                DATE_PART('month', CAST({date_column} AS TIMESTAMP)) as month,
+                DATE_PART('day', CAST({date_column} AS TIMESTAMP)) as day
+            FROM {view_name}"""
+        )
+
+        dataset_path = os.path.join(self.base_directory, dataset_identifier)
+
+        if not os.path.exists(dataset_path):
+            # Create the directory if it doesn't exist
+            os.makedirs(dataset_path)
+
+        copy_query = f"""
+            COPY (
+                SELECT * FROM processed_data
+            ) 
+            TO '{dataset_path}' 
+            (
+                FORMAT PARQUET,
+                PARTITION_BY (year, month, day),
+                OVERWRITE_OR_IGNORE 1
+            )"""
+
+        # Use the COPY command to write the data to the partitioned Parquet files
+        self.duckdb_conn.execute(copy_query)
+
+        # DROP the view to free up memory / disk space
+        self.duckdb_conn.execute("DROP VIEW processed_data")
+
+    @enforce_types
+    def _export_to_target(self, dataset_identifier: str, output_path: str):
+        """
+        Export the persistent dataset to a single Parquet file.
+        @arguments:
+            dataset_identifier - A unique identifier for the dataset.
+            output_path - The path to the output Parquet file.
+        """
+
+        view_name = self._generate_view_name(self.base_directory + dataset_identifier)
+        self.duckdb_conn.execute(
+            f"COPY {view_name} TO '{output_path}' (FORMAT PARQUET)"
+        )
+
+    @enforce_types
+    def export_to_parquet(
+        self,
+        dataset_identifier: str,
+        output_path: Optional[str] = None,
+        partition_type: Optional[str] = "date",
+        partition_column: Optional[str] = None,
+    ):
+        """
+        Finalizes the data by writing the persistent dataset to partitioned Parquet files.
+        @arguments:
+            dataset_identifier - A unique identifier for the dataset.
+            output_path - The path to the output Parquet file.
+            partition_type - The type of partitioning to use.
+            partition_column - The name of the column to partition by.
+        @example:
+            export_to_parquet("transactions", "data/transactions.parquet", "date")
+        """
+        if partition_type not in ["date", "address"]:
+            raise ValueError("partition_type must be either 'date' or 'address'")
+
+        if partition_type == "date":
+            self._export_data_with_date_hive(dataset_identifier, partition_column)
+        elif partition_type == "address":
+            self._export_data_with_address_hive(dataset_identifier, partition_column)
+        else:
+            self._export_to_target(dataset_identifier, output_path)

--- a/pdr_backend/lake/test/test_base_data_store.py
+++ b/pdr_backend/lake/test/test_base_data_store.py
@@ -1,0 +1,20 @@
+from pdr_backend.lake.base_data_store import BaseDataStore
+
+
+def _get_test_manager(tmpdir):
+    return BaseDataStore(str(tmpdir))
+
+
+def test__generate_view_name(tmpdir):
+    """
+    Test the _generate_view_name method.
+    """
+    test_manager = _get_test_manager(tmpdir)
+    view_name = test_manager._generate_view_name(str(tmpdir))
+
+    # check if the view name starts with "dataset_"
+    assert view_name.startswith(
+        "dataset_"
+    ), "The view name does not start with 'dataset_'"
+    # check if the view name continues with a hash
+    assert len(view_name) > 8, "The view name is too short"

--- a/pdr_backend/lake/test/test_partitioned_data_store.py
+++ b/pdr_backend/lake/test/test_partitioned_data_store.py
@@ -1,0 +1,191 @@
+import os
+import polars as pl
+from pdr_backend.lake.partitioned_data_store import (
+    PartitionedDataStore,
+)  # Adjust the import based on your project structure
+
+
+# Initialize the PartitionedDataStore instance for testing
+def _get_test_manager(tmpdir):
+    partitioned_ds_instance = PartitionedDataStore(str(tmpdir))
+
+    # Fill the table with some data
+    example_df = pl.DataFrame(  # pylint: disable=unused-variable
+        {
+            "timestamp": ["2022-01-01", "2022-02-01", "2022-03-01"],
+            "value": [10, 20, 30],
+            "address": ["0xasset1", "0xasset1", "0xasset2"],
+        }
+    )
+
+    dataset_identifier = "test_df"
+
+    view_name = partitioned_ds_instance._generate_view_name(
+        partitioned_ds_instance.base_directory + dataset_identifier
+    )
+
+    partitioned_ds_instance.duckdb_conn.execute(
+        f"CREATE TABLE {view_name} AS SELECT * FROM example_df"
+    )
+
+    return [partitioned_ds_instance, dataset_identifier]
+
+
+def _clean_up_test_manager(tmpdir, dataset_identifier):
+    # Clean up the test manager
+    dataset_path = os.path.join(str(tmpdir), dataset_identifier)
+
+    persistent_ds_instance = PartitionedDataStore(str(tmpdir))
+
+    view_name = persistent_ds_instance._generate_view_name(dataset_path)
+
+    # Select tables from duckdb
+    views = persistent_ds_instance.duckdb_conn.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+    ).fetchall()
+
+    # Drop the view and table
+    if view_name in [table[0] for table in views]:
+        persistent_ds_instance.duckdb_conn.execute(f"DROP TABLE {view_name}")
+
+
+def _check_folder_exists(tmpdir, dataset_identifier: str, folder: str):
+    dataset_path = os.path.join(str(tmpdir), dataset_identifier, folder)
+    folder_status = os.path.exists(dataset_path)
+    file_count = len(os.listdir(dataset_path))
+    return [folder_status, file_count, dataset_path]
+
+
+def test_export_data_with_address_hive(
+    tmpdir,
+):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="address",
+        partition_column="address",
+    )
+
+    folder_status, file_count, dataset_path = _check_folder_exists(
+        tmpdir, dataset_identifier, "address=0xasset1"
+    )
+    assert (
+        folder_status
+    ), f"Parquet Folder was not created as expected. folder: {dataset_path}"
+    assert (
+        file_count > 0
+    ), f"Parquet files was not created as expected. folder: {dataset_path}"
+
+    folder_status, file_count, dataset_path = _check_folder_exists(
+        tmpdir, dataset_identifier, "address=0xasset2"
+    )
+    assert (
+        folder_status
+    ), f"Parquet Folder was not created as expected. folder: {dataset_path}"
+    assert (
+        file_count > 0
+    ), f"Parquet files was not created as expected. folder: {dataset_path}"
+
+    _clean_up_test_manager(tmpdir, dataset_identifier)
+
+
+def test_export_data_with_date_hive(
+    tmpdir,
+):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+    print("dataset_identifier", dataset_identifier)
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="date",
+        partition_column="timestamp",
+    )
+
+    folder_status, file_count, dataset_path = _check_folder_exists(
+        tmpdir, dataset_identifier, "year=2022/month=1/day=1"
+    )
+    assert (
+        folder_status
+    ), f"Parquet Folder was not created as expected. folder: {dataset_path}"
+    assert (
+        file_count > 0
+    ), f"Parquet files was not created as expected. folder: {dataset_path}"
+
+    folder_status, file_count, dataset_path = _check_folder_exists(
+        tmpdir, dataset_identifier, "year=2022/month=2/day=1"
+    )
+    assert (
+        folder_status
+    ), f"Parquet Folder was not created as expected. folder: {dataset_path}"
+    assert (
+        file_count > 0
+    ), f"Parquet files was not created as expected. folder: {dataset_path}"
+
+    _clean_up_test_manager(tmpdir, dataset_identifier)
+
+
+def test_create_view_and_query_data(tmpdir):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="date",
+        partition_column="timestamp",
+    )
+
+    query_result = test_manager.create_view_and_query_data(
+        dataset_identifier, "SELECT * FROM {view_name} WHERE value > 15"
+    )
+    assert len(query_result) == 2, "Query did not return the expected number of rows."
+    _clean_up_test_manager(tmpdir, dataset_identifier)
+
+
+def test_create_view_and_query_data_without_view_name(tmpdir):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="date",
+        partition_column="timestamp",
+    )
+
+    try:
+        test_manager.create_view_and_query_data(
+            dataset_identifier, "SELECT * FROM {dataset_path} WHERE value > 15"
+        )
+    except ValueError as e:
+        assert str(e) == "query must contain a {view_name} placeholder"
+    _clean_up_test_manager(tmpdir, dataset_identifier)
+
+
+def test_query_data(tmpdir):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="date",
+        partition_column="timestamp",
+    )
+
+    query_result = test_manager.query_data(
+        dataset_identifier, "SELECT * FROM {dataset_path} WHERE value > 15"
+    )
+    assert len(query_result) == 2, "Query did not return the expected number of rows."
+    _clean_up_test_manager(tmpdir, dataset_identifier)
+
+
+def test_query_data_without_dataset_path(tmpdir):
+    test_manager, dataset_identifier = _get_test_manager(tmpdir)
+
+    test_manager.export_to_parquet(
+        dataset_identifier,
+        partition_type="date",
+        partition_column="timestamp",
+    )
+
+    try:
+        test_manager.query_data(
+            dataset_identifier, "SELECT * FROM {view_name} WHERE value > 15"
+        )
+    except ValueError as e:
+        assert str(e) == "query must contain a {dataset_path} placeholder"
+    _clean_up_test_manager(tmpdir, dataset_identifier)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requirements = [
     "bumpversion",
     "ccxt>=4.1.59",
     "coverage",
+    "duckdb",
     "enforce_typing",
     "eth-account",
     "eth-keys",


### PR DESCRIPTION
Fixes #651 

Changes proposed in this PR:

- [x] use the DuckDB base class
- [x] Introduced PartitionedDataStore for managing time-partitioned Parquet data (hive_partitioning, address_partitioning).
- [x] Added pytest cases in test_partitioned_data_store.py.

### PartitionedDataStore middleware:
- [x] create_view_and_query_data
- [x] query_data
- [x] _export_data_with_address_hive
- [x] _export_data_with_date_hive
- [x] _export_to_target
- [x] export_to_parquet (the 3 methods above are private and this method will handle among them)