### PR TITLE
Changed safe_fetch_ohlcv() to safe_fetch_ohlcv_ccxt()

### DIFF
--- a/pdr_backend/lake/fetch_ohlcv.py
+++ b/pdr_backend/lake/fetch_ohlcv.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("fetch_ohlcv")
 
 
 @enforce_types
-def safe_fetch_ohlcv(
+def safe_fetch_ohlcv_ccxt(
     exch,
     symbol: str,
     timeframe: str,

--- a/pdr_backend/lake/ohlcv_data_factory.py
+++ b/pdr_backend/lake/ohlcv_data_factory.py
@@ -11,7 +11,7 @@ from pdr_backend.lake.constants import (
     TOHLCV_SCHEMA_PL,
     TOHLCV_COLS,
 )
-from pdr_backend.lake.fetch_ohlcv import clean_raw_ohlcv, safe_fetch_ohlcv
+from pdr_backend.lake.fetch_ohlcv import clean_raw_ohlcv, safe_fetch_ohlcv_ccxt
 from pdr_backend.lake.merge_df import merge_rawohlcv_dfs
 from pdr_backend.lake.plutil import (
     concat_next_df,
@@ -127,7 +127,7 @@ class OhlcvDataFactory:
             limit = 1000
             logger.info("Fetch up to %s pts from %s", limit, st_ut.pretty_timestr())
             exch = feed.ccxt_exchange()
-            raw_tohlcv_data = safe_fetch_ohlcv(
+            raw_tohlcv_data = safe_fetch_ohlcv_ccxt(
                 exch,
                 symbol=str(pair_str).replace("-", "/"),
                 timeframe=str(feed.timeframe),

--- a/pdr_backend/lake/test/test_fetch_ohlcv.py
+++ b/pdr_backend/lake/test/test_fetch_ohlcv.py
@@ -3,7 +3,7 @@ import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.cli.arg_feed import ArgFeed
-from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv, clean_raw_ohlcv
+from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv_ccxt, clean_raw_ohlcv
 from pdr_backend.util.time_types import UnixTimeMs
 
 
@@ -59,30 +59,30 @@ def test_safe_fetch_ohlcv(exch):
     symbol, timeframe, limit = "ETH/USDT", "5m", 1000
 
     # happy path
-    raw_tohlc_data = safe_fetch_ohlcv(exch, symbol, timeframe, since, limit)
+    raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, symbol, timeframe, since, limit)
     assert_raw_tohlc_data_ok(raw_tohlc_data)
 
     # catch bad (but almost good) symbol
     with pytest.raises(ValueError):
-        raw_tohlc_data = safe_fetch_ohlcv(exch, "ETH-USDT", timeframe, since, limit)
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, "ETH-USDT", timeframe, since, limit)
 
     # it will catch type errors, except for exch. Test an example of this.
     with pytest.raises(TypeError):
-        raw_tohlc_data = safe_fetch_ohlcv(exch, 11, timeframe, since, limit)
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, 11, timeframe, since, limit)
     with pytest.raises(TypeError):
-        raw_tohlc_data = safe_fetch_ohlcv(exch, symbol, 11, since, limit)
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, symbol, 11, since, limit)
     with pytest.raises(TypeError):
-        raw_tohlc_data = safe_fetch_ohlcv(exch, symbol, timeframe, "f", limit)
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, symbol, timeframe, "f", limit)
     with pytest.raises(TypeError):
-        raw_tohlc_data = safe_fetch_ohlcv(exch, symbol, timeframe, since, "f")
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, symbol, timeframe, since, "f")
 
     # should not crash, just give warning
-    safe_fetch_ohlcv("bad exch", symbol, timeframe, since, limit)
-    safe_fetch_ohlcv(exch, "bad symbol", timeframe, since, limit)
-    safe_fetch_ohlcv(exch, symbol, "bad timeframe", since, limit)
+    safe_fetch_ohlcv_ccxt("bad exch", symbol, timeframe, since, limit)
+    safe_fetch_ohlcv_ccxt(exch, "bad symbol", timeframe, since, limit)
+    safe_fetch_ohlcv_ccxt(exch, symbol, "bad timeframe", since, limit)
 
     # ensure a None is returned when warning
-    v = safe_fetch_ohlcv("bad exch", symbol, timeframe, since, limit)
+    v = safe_fetch_ohlcv_ccxt("bad exch", symbol, timeframe, since, limit)
     assert v is None
 
 

--- a/pdr_backend/lake/test/test_fetch_ohlcv.py
+++ b/pdr_backend/lake/test/test_fetch_ohlcv.py
@@ -64,7 +64,9 @@ def test_safe_fetch_ohlcv(exch):
 
     # catch bad (but almost good) symbol
     with pytest.raises(ValueError):
-        raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, "ETH-USDT", timeframe, since, limit)
+        raw_tohlc_data = safe_fetch_ohlcv_ccxt(
+            exch, "ETH-USDT", timeframe, since, limit
+        )
 
     # it will catch type errors, except for exch. Test an example of this.
     with pytest.raises(TypeError):

--- a/pdr_backend/trueval/get_trueval.py
+++ b/pdr_backend/trueval/get_trueval.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv
+from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv_ccxt
 from pdr_backend.subgraph.subgraph_feed import SubgraphFeed
 from pdr_backend.util.time_types import UnixTimeS
 
@@ -41,7 +41,7 @@ def get_trueval(
     end_timestamp = end_timestamp_s.to_milliseconds()
 
     exchange = feed.ccxt_exchange()
-    tohlcvs = safe_fetch_ohlcv(
+    tohlcvs = safe_fetch_ohlcv_ccxt(
         exchange, symbol, feed.timeframe, since=init_timestamp, limit=2
     )
     assert len(tohlcvs) == 2, f"expected exactly 2 tochlv tuples. {tohlcvs}"

--- a/pdr_backend/trueval/test/test_get_trueval.py
+++ b/pdr_backend/trueval/test/test_get_trueval.py
@@ -16,7 +16,7 @@ def test_get_trueval_success(monkeypatch):
             return [[0, 0, 0, 0, 100], [300000, 0, 0, 0, 200]]
         raise ValueError(f"Invalid timestamp: since={since}")
 
-    monkeypatch.setattr(f"{_PATH}.safe_fetch_ohlcv", mock_fetch_ohlcv)
+    monkeypatch.setattr(f"{_PATH}.safe_fetch_ohlcv_ccxt", mock_fetch_ohlcv)
 
     feed = mock_feed("5m", "kraken", "ETH/USDT")
 
@@ -31,7 +31,7 @@ def test_get_trueval_fail(monkeypatch):
     def mock_fetch_ohlcv_fail(*args, **kwargs):  # pylint: disable=unused-argument
         return [[0, 0, 0, 0, 0], [300000, 0, 0, 0, 200]]
 
-    monkeypatch.setattr(f"{_PATH}.safe_fetch_ohlcv", mock_fetch_ohlcv_fail)
+    monkeypatch.setattr(f"{_PATH}.safe_fetch_ohlcv_ccxt", mock_fetch_ohlcv_fail)
 
     feed = mock_feed("5m", "kraken", "eth-usdt")
 


### PR DESCRIPTION
Changes proposed in this PR:

- Rename fetch_ohlcv.py::safe_fetch_ohlcv() -> safe_fetch_ohlcv_ccxt()