### PR TITLE
Fix #657: Float being interpreted as integer

### DIFF
--- a/pdr_backend/lake/fetch_ohlcv.py
+++ b/pdr_backend/lake/fetch_ohlcv.py
@@ -78,11 +78,19 @@ def clean_raw_ohlcv(
     """
     tohlcv_data = raw_tohlcv_data or []
     uts = _ohlcv_to_uts(tohlcv_data)
+    uts = _cast_uts_to_int(uts)
     _warn_if_uts_have_gaps(uts, feed.timeframe)
 
     tohlcv_data = _filter_within_timerange(tohlcv_data, st_ut, fin_ut)
 
     return tohlcv_data
+
+
+@enforce_types
+def _cast_uts_to_int(uts: list) -> List[int]:
+    # this could be done inside _ohlcv_to_uts
+    uts = [int(ut) for ut in uts]
+    return uts
 
 
 @enforce_types
@@ -113,4 +121,5 @@ def _filter_within_timerange(
     tohlcv_data: list, st_ut: UnixTimeMs, fin_ut: UnixTimeMs
 ) -> list:
     uts = _ohlcv_to_uts(tohlcv_data)
+    uts = _cast_uts_to_int(uts)
     return [vec for ut, vec in zip(uts, tohlcv_data) if st_ut <= ut <= fin_ut]


### PR DESCRIPTION
Fixes #657

Changes proposed in this PR:
- Improve upstream ccxt & ohclv checks such that no floats can be entered as timestamps
- Improve tests that show that floats are handled correctly before being pushed into a pl.DataFrame