### PR TITLE
#614 - Cleanup fetch_filtered_predictions

### DIFF
--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -215,10 +215,10 @@ def test_get_pdr_df_multiple_fetches():
     captured_output = StringIO()
     sys.stdout = captured_output
 
-    save_backoff_limit = 4
-    pagination_limit = 2
+    save_backoff_limit = 40
+    pagination_limit = 20
     st_timest = UnixTimeMs(1704110400000)
-    fin_timest = UnixTimeMs(1704115800000)
+    fin_timest = UnixTimeMs(1704111600000)
     table.get_pdr_df(
         fetch_function=fetch_filtered_predictions,
         network="sapphire-mainnet",
@@ -238,4 +238,4 @@ def test_get_pdr_df_multiple_fetches():
     count_saves = printed_text.count("Saved")
     assert count_saves == 2
 
-    assert len(table.df) == 5
+    assert len(table.df) == 50

--- a/pdr_backend/subgraph/subgraph_predictions.py
+++ b/pdr_backend/subgraph/subgraph_predictions.py
@@ -32,12 +32,10 @@ class FilterMode(Enum):
 def fetch_filtered_predictions(
     start_ts: UnixTimeS,
     end_ts: UnixTimeS,
-    filters: List[str],
+    addresses: List[str],
     first: int,
     skip: int,
-    network: str,
-    payout_only: bool = True,
-    trueval_only: bool = True,
+    network: str = "mainnet",
 ) -> List[Prediction]:
     """
     Fetches predictions from a subgraph within a specified time range
@@ -51,7 +49,7 @@ def fetch_filtered_predictions(
     Args:
         start_ts: The starting Unix timestamp for the query range.
         end_ts: The ending Unix timestamp for the query range.
-        filters: A list of strings representing the filter
+        addresses: A list of strings representing the filter
             values (contract addresses or predictor IDs).
         network: A string indicating the blockchain network to query ('mainnet' or 'testnet').
         filter_mode: An instance of FilterMode indicating whether to filter
@@ -63,7 +61,6 @@ def fetch_filtered_predictions(
     Raises:
         Exception: If the specified network is neither 'mainnet' nor 'testnet'.
     """
-    filter_mode = FilterMode.CONTRACT_TS
 
     if network not in ["mainnet", "testnet"]:
         raise Exception("Invalid network, pick mainnet or testnet")
@@ -71,17 +68,10 @@ def fetch_filtered_predictions(
     predictions: List[Prediction] = []
 
     # Convert filters to lowercase
-    filters = [f.lower() for f in filters]
+    filters = [f.lower() for f in addresses]
 
     # pylint: disable=line-too-long
-    if filter_mode == FilterMode.NONE:
-        where_clause = f", where: {{timestamp_gt: {start_ts}, timestamp_lt: {end_ts}}}"
-    elif filter_mode == FilterMode.CONTRACT_TS:
-        where_clause = f", where: {{timestamp_gt: {start_ts}, timestamp_lt: {end_ts}, slot_: {{predictContract_in: {json.dumps(filters)}}}}}"
-    elif filter_mode == FilterMode.CONTRACT:
-        where_clause = f", where: {{slot_: {{predictContract_in: {json.dumps(filters)}, slot_gt: {start_ts}, slot_lt: {end_ts}}}}}"
-    elif filter_mode == FilterMode.PREDICTOOR:
-        where_clause = f", where: {{user_: {{id_in: {json.dumps(filters)}}}, slot_: {{slot_gt: {start_ts}, slot_lt: {end_ts}}}}}"
+    where_clause = f", where: {{timestamp_gt: {start_ts}, timestamp_lt: {end_ts}, slot_: {{predictContract_in: {json.dumps(filters)}}}}}"
 
     query = f"""
         {{
@@ -154,17 +144,11 @@ def fetch_filtered_predictions(
         predicted_value = None
         stake = None
 
-        if payout_only is True and prediction_sg_dict["payout"] is None:
-            continue
-
         if not prediction_sg_dict["payout"] is None:
             stake = float(prediction_sg_dict["stake"])
             trueval = prediction_sg_dict["payout"]["trueValue"]
             predicted_value = prediction_sg_dict["payout"]["predictedValue"]
             payout = float(prediction_sg_dict["payout"]["payout"])
-
-        if trueval_only is True and trueval is None:
-            continue
 
         prediction = Prediction(
             ID=prediction_sg_dict["id"],

--- a/pdr_backend/subgraph/test/test_subgraph_predictions.py
+++ b/pdr_backend/subgraph/test/test_subgraph_predictions.py
@@ -119,7 +119,7 @@ def test_fetch_filtered_predictions(mock_query_subgraph):
         end_ts=UnixTimeS(1622548800),
         first=1000,
         skip=0,
-        filters=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
+        addresses=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
         network="mainnet",
     )
 
@@ -161,7 +161,7 @@ def test_fetch_filtered_predictions_exception(mock_query_subgraph):
         end_ts=UnixTimeS(1622548800),
         first=1000,
         skip=0,
-        filters=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
+        addresses=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
         network="mainnet",
     )
 
@@ -178,7 +178,7 @@ def test_fetch_filtered_predictions_no_data():
             end_ts=UnixTimeS(1622548800),
             first=1000,
             skip=0,
-            filters=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
+            addresses=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
             network="xyz",
         )
 
@@ -191,7 +191,7 @@ def test_fetch_filtered_predictions_no_data():
             end_ts=UnixTimeS(1622548800),
             first=1000,
             skip=0,
-            filters=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
+            addresses=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
             network="mainnet",
         )
     assert len(predictions) == 0
@@ -205,7 +205,7 @@ def test_fetch_filtered_predictions_no_data():
             end_ts=UnixTimeS(1622548800),
             first=1000,
             skip=0,
-            filters=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
+            addresses=["0x18f54cc21b7a2fdd011bea06bba7801b280e3151"],
             network="mainnet",
         )
     assert len(predictions) == 0


### PR DESCRIPTION
Fixes #614 

Changes proposed in this PR:

- Unnecessary logic is removed
- The function sign is fixed
- all fetcher signs are the same now: UnixTimeS,UnixTimeS,List[str],int,int,str = "mainnet"