### PR TITLE
Add safe fetch ohlcv dydx method

### DIFF
--- a/pdr_backend/lake/fetch_ohlcv.py
+++ b/pdr_backend/lake/fetch_ohlcv.py
@@ -55,6 +55,7 @@ def safe_fetch_ohlcv_ccxt(
         logger.warning("exchange: %s", e)
         return None
 
+
 @enforce_types
 def safe_fetch_ohlcv_dydx(
     exch,
@@ -82,16 +83,17 @@ def safe_fetch_ohlcv_dydx(
     """
 
     try:
-         if exch == "dydx":
-            since=UnixTimeMs.to_iso_timestr(since)
+        if exch == "dydx":
+            sinceIso = since.to_iso_timestr()
             headers = {"Accept": "application/json"}
             response = requests.get(
-                f"https://indexer.dydx.trade/v4/candles/perpetualMarkets/{symbol}?resolution={timeframe}&fromISO={since}&limit={limit}",
+                f"https://indexer.dydx.trade/v4/candles/perpetualMarkets/{symbol}?resolution={timeframe}&fromISO={sinceIso}&limit={limit}",
                 headers=headers,
             )
             data = response.json()
-            print(data)
             return data
+        else:
+            return None
     except Exception as e:
         logger.warning("exchange: %s", e)
         return None

--- a/pdr_backend/lake/test/test_fetch_ohlcv.py
+++ b/pdr_backend/lake/test/test_fetch_ohlcv.py
@@ -1,5 +1,5 @@
 import ccxt
-from datetime import datetime, timedelta, timezone  # DELETE
+from datetime import datetime, timedelta, timezone
 import pytest
 from enforce_typing import enforce_types
 

--- a/pdr_backend/lake/test/test_fetch_ohlcv.py
+++ b/pdr_backend/lake/test/test_fetch_ohlcv.py
@@ -1,9 +1,10 @@
 import ccxt
+from datetime import datetime, timedelta, timezone #DELETE
 import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.cli.arg_feed import ArgFeed
-from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv_ccxt, clean_raw_ohlcv
+from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv_ccxt, safe_fetch_ohlcv_dydx, clean_raw_ohlcv
 from pdr_backend.util.time_types import UnixTimeMs
 
 
@@ -58,7 +59,7 @@ def test_safe_fetch_ohlcv(exch):
     since = UnixTimeMs.from_timestr("2023-06-18")
     symbol, timeframe, limit = "ETH/USDT", "5m", 1000
 
-    # happy path
+    # happy path ccxt
     raw_tohlc_data = safe_fetch_ohlcv_ccxt(exch, symbol, timeframe, since, limit)
     assert_raw_tohlc_data_ok(raw_tohlc_data)
 
@@ -87,6 +88,11 @@ def test_safe_fetch_ohlcv(exch):
     v = safe_fetch_ohlcv_ccxt("bad exch", symbol, timeframe, since, limit)
     assert v is None
 
+    # happy path dydx
+    fifteen_min_ago = datetime.now(timezone.utc) - timedelta(minutes=15)
+    symbol, timeframe, since, limit = ("BTC-USD", "5MINS", UnixTimeMs.from_dt(fifteen_min_ago), 100)
+    result = safe_fetch_ohlcv_dydx("dydx", symbol, timeframe, since, limit)
+    assert_safe_fetch_ohlcv_dydx_ok(result)
 
 @enforce_types
 def assert_raw_tohlc_data_ok(raw_tohlc_data):
@@ -97,3 +103,10 @@ def assert_raw_tohlc_data_ok(raw_tohlc_data):
         assert isinstance(item[0], int)
         for val in item[1:]:
             assert isinstance(val, float)
+
+@enforce_types
+def assert_safe_fetch_ohlcv_dydx_ok(result):
+    # Result should return one list called 'candles' that contains 3 lists of 100 candles data
+    assert result is not None
+    assert len(result) == 1
+    assert len(result['candles']) == 3

--- a/pdr_backend/lake/test/test_fetch_ohlcv.py
+++ b/pdr_backend/lake/test/test_fetch_ohlcv.py
@@ -1,10 +1,14 @@
 import ccxt
-from datetime import datetime, timedelta, timezone #DELETE
+from datetime import datetime, timedelta, timezone  # DELETE
 import pytest
 from enforce_typing import enforce_types
 
 from pdr_backend.cli.arg_feed import ArgFeed
-from pdr_backend.lake.fetch_ohlcv import safe_fetch_ohlcv_ccxt, safe_fetch_ohlcv_dydx, clean_raw_ohlcv
+from pdr_backend.lake.fetch_ohlcv import (
+    safe_fetch_ohlcv_ccxt,
+    safe_fetch_ohlcv_dydx,
+    clean_raw_ohlcv,
+)
 from pdr_backend.util.time_types import UnixTimeMs
 
 
@@ -90,9 +94,15 @@ def test_safe_fetch_ohlcv(exch):
 
     # happy path dydx
     fifteen_min_ago = datetime.now(timezone.utc) - timedelta(minutes=15)
-    symbol, timeframe, since, limit = ("BTC-USD", "5MINS", UnixTimeMs.from_dt(fifteen_min_ago), 100)
+    symbol, timeframe, since, limit = (
+        "BTC-USD",
+        "5MINS",
+        UnixTimeMs.from_dt(fifteen_min_ago),
+        100,
+    )
     result = safe_fetch_ohlcv_dydx("dydx", symbol, timeframe, since, limit)
     assert_safe_fetch_ohlcv_dydx_ok(result)
+
 
 @enforce_types
 def assert_raw_tohlc_data_ok(raw_tohlc_data):
@@ -104,9 +114,10 @@ def assert_raw_tohlc_data_ok(raw_tohlc_data):
         for val in item[1:]:
             assert isinstance(val, float)
 
+
 @enforce_types
 def assert_safe_fetch_ohlcv_dydx_ok(result):
     # Result should return one list called 'candles' that contains 3 lists of 100 candles data
     assert result is not None
     assert len(result) == 1
-    assert len(result['candles']) == 3
+    assert len(result["candles"]) == 3

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -81,7 +81,7 @@ class UnixTimeMs(int):
     def to_iso_timestr(self) -> str:
         dt: datetime = self.to_dt()
 
-        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z" # tack on timezone
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"  # tack on timezone
 
     def pretty_timestr(self) -> str:
         return f"timestamp={self}, dt={self.to_timestr()}"

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -78,5 +78,10 @@ class UnixTimeMs(int):
 
         return dt.strftime("%Y-%m-%d_%H:%M:%S.%f")[:-3]
 
+    def to_iso_timestr(self) -> str:
+        dt: datetime = self.to_dt()
+
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z" # tack on timezone
+
     def pretty_timestr(self) -> str:
         return f"timestamp={self}, dt={self.to_timestr()}"


### PR DESCRIPTION
PR towards solving #493.

Changes proposed in this PR:

- Added safe_fetch_ohlcv_dydx() to fetch_ohlcv.py file using the same convention as safe_fetch_ohlcv_ccxt()
- Added happy path unit test
- Added new time utility function to_iso_timestr() to convert UnixTimeMs to string format expected by dydx