### PR TITLE
Fix #684: [Sim] Change 1d profit scatterplots to 2d

### DIFF
--- a/pdr_backend/lake/fetch_ohlcv.py
+++ b/pdr_backend/lake/fetch_ohlcv.py
@@ -91,11 +91,13 @@ def safe_fetch_ohlcv_dydx(
             f"https://indexer.dydx.trade/v4/candles/perpetualMarkets/{symbol}"
             + f"?resolution={timeframe}&fromISO={sinceIso}&limit={limit}",
             headers=headers,
+            timeout=20,
         )
         response = requests.get(
             "https://indexer.dydx.trade/v4/candles/perpetualMarkets/BTC-USD"
             + "?resolution=5MINS&fromISO=2024-02-27T00:00:00.000Z&limit=1",
             headers=headers,
+            timeout=20,
         )
         data = response.json()
         return data

--- a/pdr_backend/sim/sim_engine.py
+++ b/pdr_backend/sim/sim_engine.py
@@ -442,7 +442,7 @@ class PlotState:
             ax10.margins(0.005, 0.05)
 
         # reusable profits scatterplot
-        def _scatter_profits(ax, actor: str, denomin, mnp, mxp, st_profits):
+        def _scatter_profits(ax, actor: str, denomin, st_profits):
             next_probs_up = _slice(st.probs_up, N_done, N)
             next_profits = _slice(st_profits, N_done, N)
             c = (random(), random(), random())  # random RGB color
@@ -450,9 +450,9 @@ class PlotState:
             avg = np.average(st_profits)
             s = f"{actor} profit distr'n. avg={avg:.2f} {denomin}"
             _set_title(ax, s)
+            ax.plot([0.5, 0.5], [mnp, mxp], c="0.2", ls="-", lw=1)
             if not self.plotted_before:
                 ax.plot([0.0, 1.0], [0, 0], c="0.2", ls="--", lw=1)
-                ax.plot([0.5, 0.5], [mnp, mxp], c="0.2", ls="--", lw=1)
                 _set_xlabel(ax, f"prob(up)")
                 _set_ylabel(ax, f"{actor} profit ({denomin})")
                 _ylabel_on_right(ax)
@@ -463,7 +463,7 @@ class PlotState:
         _scatter_profits(ax11, "pdr", "OCEAN", mnp, mxp, pdr_profits_OCEAN)
 
         # plot row 1, col 2: 1d scatter of trader profits
-        mnp, mxp = -tdr_ss.buy_amt_usd / 1000.0, +tdr_ss.buy_amt_usd / 1000.0
+        mnp, mxp = min(trader_profits_USD), max(trader_profits_USD)
         _scatter_profits(ax12, "trader", "USD", mnp, mxp, trader_profits_USD)
 
         # final pieces

--- a/pdr_backend/sim/sim_engine.py
+++ b/pdr_backend/sim/sim_engine.py
@@ -368,7 +368,7 @@ class PlotState:
 
     # pylint: disable=too-many-statements
     def make_plot(self, st, ppss, model, X_train, ybool_train, colnames):
-        pdr_ss, tdr_ss = ppss.predictoor_ss, ppss.trader_ss
+        pdr_ss = ppss.predictoor_ss
         fig = self.fig
         ax00, ax01 = self.ax00, self.ax01
         ax10, ax11, ax12 = self.ax10, self.ax11, self.ax12
@@ -442,18 +442,18 @@ class PlotState:
             ax10.margins(0.005, 0.05)
 
         # reusable profits scatterplot
-        def _scatter_profits(ax, actor: str, denomin, st_profits):
+        def _scatter_profits(ax, actor: str, denomin, mnp, mxp, st_profits):
             next_probs_up = _slice(st.probs_up, N_done, N)
             next_profits = _slice(st_profits, N_done, N)
             c = (random(), random(), random())  # random RGB color
-            ax.scatter(next_probs_up, next_profits, c=c, s=1)
+            ax.scatter(next_probs_up, next_profits, color=c, s=1)
             avg = np.average(st_profits)
             s = f"{actor} profit distr'n. avg={avg:.2f} {denomin}"
             _set_title(ax, s)
             ax.plot([0.5, 0.5], [mnp, mxp], c="0.2", ls="-", lw=1)
             if not self.plotted_before:
                 ax.plot([0.0, 1.0], [0, 0], c="0.2", ls="--", lw=1)
-                _set_xlabel(ax, f"prob(up)")
+                _set_xlabel(ax, "prob(up)")
                 _set_ylabel(ax, f"{actor} profit ({denomin})")
                 _ylabel_on_right(ax)
                 ax.margins(0.05, 0.05)

--- a/pdr_backend/util/currency_types.py
+++ b/pdr_backend/util/currency_types.py
@@ -75,6 +75,14 @@ class Eth:
 
         return Eth(self.amt_eth + other)
 
+    def __pos__(self) -> "Eth":
+        """This is the unary '+' operator"""
+        return Eth(self.amt_eth)
+
+    def __neg__(self) -> "Eth":
+        """This is the unary '-' operator"""
+        return Eth(-self.amt_eth)
+
 
 @enforce_types
 class Wei:
@@ -129,3 +137,11 @@ class Wei:
             return Wei(self.amt_wei - other.amt_wei)
 
         return Wei(self.amt_wei - other)
+
+    def __pos__(self) -> "Wei":
+        """This is the unary '+' operator"""
+        return Wei(self.amt_wei)
+
+    def __neg__(self) -> "Wei":
+        """This is the unary '-' operator"""
+        return Wei(-self.amt_wei)

--- a/pdr_backend/util/test_noganache/test_currency_types.py
+++ b/pdr_backend/util/test_noganache/test_currency_types.py
@@ -19,6 +19,7 @@ def test_currency_types_base():
 
 @enforce_types
 def test_currency_types_math_on_Eth():
+    # pylint: disable=pointless-statement
     x1, x2 = Eth(5.0), Eth(2.5)
 
     assert +x1 == Eth(5.0)
@@ -51,6 +52,7 @@ def test_currency_types_math_on_Eth():
 
 @enforce_types
 def test_currency_types_math_on_Wei():
+    # pylint: disable=pointless-statement
     x1, x2 = Wei(5000), Wei(2500)
 
     assert +x1 == Wei(5000)

--- a/pdr_backend/util/test_noganache/test_currency_types.py
+++ b/pdr_backend/util/test_noganache/test_currency_types.py
@@ -1,0 +1,76 @@
+from enforce_typing import enforce_types
+import pytest
+
+from pdr_backend.util.currency_types import Eth, Wei
+
+
+@enforce_types
+def test_currency_types_base():
+    assert Wei(int(1234 * 1e18)).to_eth() == Eth(1234)
+    assert Wei(int(12.34 * 1e18)).to_eth() == Eth(12.34)
+    assert Wei(int(0.1234 * 1e18)).to_eth() == Eth(0.1234)
+
+    assert Eth(1234).to_wei() == Wei(1234 * 1e18) and type(Eth(1234).to_wei()) == Wei
+    assert Eth(12.34).to_wei() == Wei(12.34 * 1e18)
+    assert Eth(0.1234).to_wei() == Wei(0.1234 * 1e18)
+
+    assert Wei(int(12.34 * 1e18)).str_with_wei() == "12.34 (12340000000000000000 wei)"
+
+
+@enforce_types
+def test_currency_types_math_on_Eth():
+    x1, x2 = Eth(5.0), Eth(2.5)
+
+    assert +x1 == Eth(5.0)
+    assert -x1 == Eth(-5.0)
+
+    assert (x1 + x2) == Eth(7.5)
+    assert (x1 - x2) == Eth(2.5)
+    assert (x2 - x1) == Eth(-2.5)
+
+    assert (x1 * x2) == Eth(12.5)
+    assert (x1 / x2) == Eth(2.0)
+    assert (x2 / x1) == Eth(0.5)
+
+    assert x1 * 2 == Eth(10.0)
+    assert x1 * 2.0 == Eth(10.0)
+
+    assert x1 / 2 == Eth(2.5)
+    assert x1 / 2.5 == Eth(2.0)
+
+    # don't bother overriding these (more complex)
+    with pytest.raises(TypeError):
+        2 * x1
+    with pytest.raises(TypeError):
+        2.0 * x1
+    with pytest.raises(TypeError):
+        10 / x1
+    with pytest.raises(TypeError):
+        10.0 / x1
+
+
+@enforce_types
+def test_currency_types_math_on_Wei():
+    x1, x2 = Wei(5000), Wei(2500)
+
+    assert +x1 == Wei(5000)
+    assert -x1 == Wei(-5000)
+
+    assert (x1 + x2) == Wei(7500)
+    assert (x1 - x2) == Wei(2500)
+    assert (x2 - x1) == Wei(-2500)
+
+    # don't bother overriding these (more complex, or dangerous)
+    with pytest.raises(TypeError):
+        x1 * x2
+    with pytest.raises(TypeError):
+        x1 / x2
+
+    with pytest.raises(TypeError):
+        2 * x1
+    with pytest.raises(TypeError):
+        2.0 * x1
+    with pytest.raises(TypeError):
+        10 / x1
+    with pytest.raises(TypeError):
+        10.0 / x1

--- a/pdr_backend/util/test_noganache/test_mathutil.py
+++ b/pdr_backend/util/test_noganache/test_mathutil.py
@@ -12,7 +12,6 @@ from pdr_backend.util.mathutil import (
     round_sig,
     string_to_bytes32,
 )
-from pdr_backend.util.currency_types import Eth, Wei
 
 
 @enforce_types
@@ -180,19 +179,6 @@ def test_classif_acc():
 
     ybool_hat = np.array([True, False, False, True])
     assert classif_acc(ybool_hat, ybool) == 0.75
-
-
-@enforce_types
-def test_wei():
-    assert Wei(int(1234 * 1e18)).to_eth() == Eth(1234)
-    assert Wei(int(12.34 * 1e18)).to_eth() == Eth(12.34)
-    assert Wei(int(0.1234 * 1e18)).to_eth() == Eth(0.1234)
-
-    assert Eth(1234).to_wei() == Wei(1234 * 1e18) and type(Eth(1234).to_wei()) == Wei
-    assert Eth(12.34).to_wei() == Wei(12.34 * 1e18)
-    assert Eth(0.1234).to_wei() == Wei(0.1234 * 1e18)
-
-    assert Wei(int(12.34 * 1e18)).str_with_wei() == "12.34 (12340000000000000000 wei)"
 
 
 @enforce_types


### PR DESCRIPTION
Fixes #684 

Also:
- Fix [#707](https://github.com/oceanprotocol/pdr-backend/issues/707) [Linter bug] Pylint failures in safe_fetch_ohlcv_dydx. Why here: it was causing my CI to fail, and easy to fix
- For [#547](https://github.com/oceanprotocol/pdr-backend/issues/547) Eth/Weth currency_types: (a) Move tests from test_mathutil.py to new dedicated test module test_currency_types.py. (b) Add support for unary +/- operators (c) Add tests for math operators +, -, *, /, and unary +/-. Why here: because sim_engine uses it
