### PR TITLE
Fix #756 - Removing generate_view_name and simplify db.query()

### DIFF
--- a/pdr_backend/lake/base_data_store.py
+++ b/pdr_backend/lake/base_data_store.py
@@ -20,20 +20,6 @@ class BaseDataStore:
             database=f"{self.base_directory}/duckdb.db"
         )  # Keep a persistent connection
 
-    @enforce_types
-    def _generate_view_name(self, base_path=str) -> str:
-        """
-        Generate a unique view name for a given base path.
-        @arguments:
-            base_path - The base path to generate a view name for.
-        @returns:
-            str - A unique view name.
-        """
-
-        path = f"{self.base_directory}/{base_path}"
-        hash_object = md5(path.encode())
-        return f"dataset_{hash_object.hexdigest()}"
-
     @abstractmethod
     def query_data(
         self,

--- a/pdr_backend/lake/base_data_store.py
+++ b/pdr_backend/lake/base_data_store.py
@@ -1,4 +1,3 @@
-from hashlib import md5
 from abc import abstractmethod
 from typing import Optional, Literal
 
@@ -23,7 +22,6 @@ class BaseDataStore:
     @abstractmethod
     def query_data(
         self,
-        dataset_identifier: str,
         query: str,
         partition_type: Optional[Literal["date", "address"]] = None,
     ):

--- a/pdr_backend/lake/persistent_data_store.py
+++ b/pdr_backend/lake/persistent_data_store.py
@@ -23,28 +23,25 @@ class PersistentDataStore(BaseDataStore):
 
     @enforce_types
     def _create_and_fill_table(
-        self, df: pl.DataFrame, dataset_identifier: str
+        self, df: pl.DataFrame, table_name: str
     ):  # pylint: disable=unused-argument
         """
-        Create the dataset and insert data to the persistent dataset.
+        Create the table and insert data
         @arguments:
             df - The Polars DataFrame to append.
             dataset_identifier - A unique identifier for the dataset.
         """
 
-        view_name = self._generate_view_name(dataset_identifier)
-
-        # self.duckdb_conn.register(view_name, df)
         # Create the table
-        self.duckdb_conn.execute(f"CREATE TABLE {view_name} AS SELECT * FROM df")
+        self.duckdb_conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM df")
 
     @enforce_types
-    def insert_to_table(self, df: pl.DataFrame, dataset_identifier: str):
+    def insert_to_table(self, df: pl.DataFrame, table_name: str):
         """
         Insert data to an persistent dataset.
         @arguments:
             df - The Polars DataFrame to append.
-            dataset_identifier - A unique identifier for the dataset.
+            table_name - A unique table.
         @example:
             df = pl.DataFrame({
                 "id": [1, 2, 3],
@@ -54,43 +51,38 @@ class PersistentDataStore(BaseDataStore):
             insert_to_table(df, "people")
         """
 
-        view_name = self._generate_view_name(dataset_identifier)
         # Check if the table exists
         tables = self.duckdb_conn.execute(
             "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
         ).fetchall()
 
-        if view_name in [table[0] for table in tables]:
-            self.duckdb_conn.execute(f"INSERT INTO {view_name} SELECT * FROM df")
+        if table_name in [table[0] for table in tables]:
+            self.duckdb_conn.execute(f"INSERT INTO {table_name} SELECT * FROM df")
         else:
-            self._create_and_fill_table(df, dataset_identifier)
+            self._create_and_fill_table(df, table_name)
 
     @enforce_types
-    def query_data(
-        self, dataset_identifier: str, query: str, partition_type: None = None
-    ) -> pl.DataFrame:
+    def query_data(self, query: str, partition_type: None = None) -> pl.DataFrame:
         """
         Execute a SQL query across the persistent dataset using DuckDB.
         @arguments:
-            dataset_identifier - A unique identifier for the dataset.
+            table_name - A unique name for the table.
             query - The SQL query to execute.
         @returns:
             pl.DataFrame - The result of the query.
         @example:
-            query_data("people", "SELECT * FROM {view_name}")
+            query_data("SELECT * FROM table_name")
         """
 
-        view_name = self._generate_view_name(dataset_identifier)
-        result_df = self.duckdb_conn.execute(query.format(view_name=view_name)).df()
-
-        return pl.DataFrame(result_df)
+        result_df = self.duckdb_conn.execute(query).pl()
+        return result_df
 
     @enforce_types
-    def drop_table(self, dataset_identifier: str, ds_type: str = "table"):
+    def drop_table(self, table_name: str, ds_type: str = "table"):
         """
-        Drop the persistent dataset.
+        Drop the persistent table.
         @arguments:
-            dataset_identifier - A unique identifier for the dataset.
+            table_name - A unique name for the table.
             ds_type - The type of the dataset to drop. Either "table" or "view".
         @example:
             drop_table("people")
@@ -99,16 +91,15 @@ class PersistentDataStore(BaseDataStore):
         if ds_type not in ["view", "table"]:
             raise ValueError("ds_type must be either 'view' or 'table'")
 
-        view_name = self._generate_view_name(dataset_identifier)
-        self.duckdb_conn.execute(f"DROP {ds_type} {view_name}")
+        self.duckdb_conn.execute(f"DROP {ds_type} {table_name}")
 
     @enforce_types
-    def fill_from_csv_destination(self, csv_folder_path: str, dataset_identifier: str):
+    def fill_from_csv_destination(self, csv_folder_path: str, table_name: str):
         """
         Fill the persistent dataset from CSV files.
         @arguments:
             csv_folder_path - The path to the folder containing the CSV files.
-            dataset_identifier - A unique identifier for the dataset.
+            table_name - A unique name for the table.
         @example:
             fill_from_csv_destination("data/csv", "people")
         """
@@ -118,18 +109,16 @@ class PersistentDataStore(BaseDataStore):
         print("csv_files", csv_files)
         for csv_file in csv_files:
             df = pl.read_csv(csv_file)
-            self.insert_to_table(df, dataset_identifier)
+            self.insert_to_table(df, table_name)
 
     @enforce_types
-    def update_data(
-        self, df: pl.DataFrame, dataset_identifier: str, identifier_column: str
-    ):
+    def update_data(self, df: pl.DataFrame, table_name: str, column_name: str):
         """
         Update the persistent dataset with the provided DataFrame.
         @arguments:
             df - The Polars DataFrame to update.
-            dataset_identifier - A unique identifier for the dataset.
-            identifier_column - The column to use as the identifier for the update.
+            table_name - A unique name for the table.
+            column_name - The column to use as the index for the update.
         @example:
             df = pl.DataFrame({
                 "id": [1, 2, 3],
@@ -139,12 +128,11 @@ class PersistentDataStore(BaseDataStore):
             update_data(df, "people", "id")
         """
 
-        view_name = self._generate_view_name(dataset_identifier)
         update_columns = ", ".join(
             [f"{column} = {df[column]}" for column in df.columns]
         )
         self.duckdb_conn.execute(
-            f"""UPDATE {view_name} 
+            f"""UPDATE {table_name} 
             SET {update_columns} 
-            WHERE {identifier_column} = {df[identifier_column]}"""
+            WHERE {column_name} = {df[column_name]}"""
         )

--- a/pdr_backend/lake/test/test_base_data_store.py
+++ b/pdr_backend/lake/test/test_base_data_store.py
@@ -1,20 +1,16 @@
 from pdr_backend.lake.base_data_store import BaseDataStore
+import duckdb
 
 
-def _get_test_manager(tmpdir):
+def _get_data_store(tmpdir):
     return BaseDataStore(str(tmpdir))
 
 
-def test__generate_view_name(tmpdir):
+def test__duckdb_connection(tmpdir):
     """
-    Test the _generate_view_name method.
+    Test datastore.
     """
-    test_manager = _get_test_manager(tmpdir)
-    view_name = test_manager._generate_view_name(str(tmpdir))
-
-    # check if the view name starts with "dataset_"
-    assert view_name.startswith(
-        "dataset_"
-    ), "The view name does not start with 'dataset_'"
-    # check if the view name continues with a hash
-    assert len(view_name) > 8, "The view name is too short"
+    data_store = _get_data_store(tmpdir)
+    assert isinstance(
+        data_store.duckdb_conn, duckdb.DuckDBPyConnection
+    ), "The connection is not a DuckDBPyConnection"

--- a/pdr_backend/lake/test/test_base_data_store.py
+++ b/pdr_backend/lake/test/test_base_data_store.py
@@ -1,5 +1,5 @@
-from pdr_backend.lake.base_data_store import BaseDataStore
 import duckdb
+from pdr_backend.lake.base_data_store import BaseDataStore
 
 
 def _get_data_store(tmpdir):

--- a/pdr_backend/lake/test/test_csv_data_store.py
+++ b/pdr_backend/lake/test/test_csv_data_store.py
@@ -4,7 +4,7 @@ import polars as pl
 from pdr_backend.lake.csv_data_store import CSVDataStore
 
 
-def _get_test_manager(tmpdir):
+def _get_data_store(tmpdir):
     return CSVDataStore(str(tmpdir))
 
 
@@ -19,28 +19,28 @@ def _clean_up(tmpdir):
 
 
 def test_get_folder_path(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    folder_path = manager._get_folder_path("test")
+    csv_data_store = _get_data_store(tmpdir)
+    folder_path = csv_data_store._get_folder_path("test")
     assert folder_path == f"{tmpdir}/test"
 
 
 def test_create_file_name(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_name = manager._create_file_name("test", 1707030362, 1709060200)
+    csv_data_store = _get_data_store(tmpdir)
+    file_name = csv_data_store._create_file_name("test", 1707030362, 1709060200)
     print("file_name---", file_name)
     assert file_name == "test_from_1707030362_to_1709060200.csv"
 
 
 def test_get_file_paths(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_name_1 = manager._create_file_name("test", 0, 20)
-    file_name_2 = manager._create_file_name("test", 21, 40)
-    file_name_3 = manager._create_file_name("test", 41, 60)
-    file_name_4 = manager._create_file_name("test", 61, 80)
+    csv_data_store = _get_data_store(tmpdir)
+    file_name_1 = csv_data_store._create_file_name("test", 0, 20)
+    file_name_2 = csv_data_store._create_file_name("test", 21, 40)
+    file_name_3 = csv_data_store._create_file_name("test", 41, 60)
+    file_name_4 = csv_data_store._create_file_name("test", 61, 80)
 
     files = [file_name_1, file_name_2, file_name_3, file_name_4]
 
-    folder_path = manager._get_folder_path("test")
+    folder_path = csv_data_store._get_folder_path("test")
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
@@ -54,7 +54,7 @@ def test_get_file_paths(tmpdir):
     for file in files:
         assert os.path.exists(folder_path + "/" + file)
 
-    file_paths = manager._get_file_paths(folder_path, 21, 60)
+    file_paths = csv_data_store._get_file_paths(folder_path, 21, 60)
 
     for file_path in file_paths:
         assert file_path in [
@@ -66,35 +66,35 @@ def test_get_file_paths(tmpdir):
 
 
 def test_create_file_path(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_path = manager._create_file_path("test", 1, 2)
+    csv_data_store = _get_data_store(tmpdir)
+    file_path = csv_data_store._create_file_path("test", 1, 2)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_0000000002.csv"
 
 
 def test_create_file_path_without_endtime(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_path = manager._create_file_path("test", 1, None)
+    csv_data_store = _get_data_store(tmpdir)
+    file_path = csv_data_store._create_file_path("test", 1, None)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_.csv"
 
 
 def test_read(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_path = manager._create_file_path("test", 1, 2)
+    csv_data_store = _get_data_store(tmpdir)
+    file_path = csv_data_store._create_file_path("test", 1, 2)
 
     with open(file_path, "w") as file:
         file.write("a,b,c\n1,2,3\n4,5,6")
 
-    data = manager.read("test", 1, 2)
+    data = csv_data_store.read("test", 1, 2)
     assert data.equals(pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]}))
 
     _clean_up(tmpdir)
 
 
 def test_read_all(tmpdir):
-    manager = _get_test_manager(tmpdir)
+    csv_data_store = _get_data_store(tmpdir)
 
-    file_path_1 = manager._create_file_path("test", 0, 20)
-    file_path_2 = manager._create_file_path("test", 21, 41)
+    file_path_1 = csv_data_store._create_file_path("test", 0, 20)
+    file_path_2 = csv_data_store._create_file_path("test", 21, 41)
 
     with open(file_path_1, "w") as file:
         file.write("a,b,c\n1,2,3\n4,5,6")
@@ -102,7 +102,7 @@ def test_read_all(tmpdir):
     with open(file_path_2, "w") as file:
         file.write("a,b,c\n7,8,9\n10,11,12")
 
-    data = manager.read_all("test")
+    data = csv_data_store.read_all("test")
     assert data["a"].to_list() == [1, 4, 7, 10]
     assert data["b"].to_list() == [2, 5, 8, 11]
     assert data["c"].to_list() == [3, 6, 9, 12]
@@ -111,15 +111,15 @@ def test_read_all(tmpdir):
 
 
 def test_get_last_file_path(tmpdir):
-    manager = _get_test_manager(tmpdir)
-    file_path_1 = manager._create_file_path("test", 0, 20)
-    file_path_2 = manager._create_file_path("test", 21, 41)
-    file_path_3 = manager._create_file_path("test", 42, 62)
-    file_path_4 = manager._create_file_path("test", 63, 83)
+    csv_data_store = _get_data_store(tmpdir)
+    file_path_1 = csv_data_store._create_file_path("test", 0, 20)
+    file_path_2 = csv_data_store._create_file_path("test", 21, 41)
+    file_path_3 = csv_data_store._create_file_path("test", 42, 62)
+    file_path_4 = csv_data_store._create_file_path("test", 63, 83)
 
     files = [file_path_1, file_path_2, file_path_3, file_path_4]
 
-    folder_path = manager._get_folder_path("test")
+    folder_path = csv_data_store._get_folder_path("test")
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
@@ -129,7 +129,7 @@ def test_get_last_file_path(tmpdir):
         with open(os.path.join(folder_path, file), "w"):
             pass
 
-    assert manager._get_last_file_path(f"{tmpdir}/test") == os.path.join(
+    assert csv_data_store._get_last_file_path(f"{tmpdir}/test") == os.path.join(
         folder_path, file_path_4
     )
 
@@ -137,10 +137,10 @@ def test_get_last_file_path(tmpdir):
 
 
 def test_write(tmpdir):
-    manager = _get_test_manager(tmpdir)
+    csv_data_store = _get_data_store(tmpdir)
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
-    manager.write("test", data)
-    file_name = manager._create_file_path("test", 3, None)
+    csv_data_store.write("test", data)
+    file_name = csv_data_store._create_file_path("test", 3, None)
 
     data = pl.read_csv(file_name)
 
@@ -154,7 +154,7 @@ def test_write(tmpdir):
 def test_write_1000_rows(tmpdir):
     _clean_up(tmpdir)
 
-    manager = _get_test_manager(tmpdir)
+    csv_data_store = _get_data_store(tmpdir)
     data = pl.DataFrame(
         {
             "a": list(range(1000)),
@@ -162,16 +162,16 @@ def test_write_1000_rows(tmpdir):
             "timestamp": list(range(1000)),
         }
     )
-    manager.write("test", data)
+    csv_data_store.write("test", data)
 
-    # folder_path = manager._get_folder_path("test")
+    # folder_path = csv_data_store._get_folder_path("test")
 
     # get folder including files
     # folder = os.listdir(folder_path)
     # print folder files
     # print("folder---", folder)
 
-    file_name = manager._create_file_path("test", 0, 999)
+    file_name = csv_data_store._create_file_path("test", 0, 999)
 
     data = pl.read_csv(file_name)
 
@@ -183,15 +183,15 @@ def test_write_1000_rows(tmpdir):
 
 
 def test_write_append(tmpdir):
-    manager = _get_test_manager(tmpdir)
+    csv_data_store = _get_data_store(tmpdir)
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
-    manager.write("test", data)
+    csv_data_store.write("test", data)
 
     # new data
     data = pl.DataFrame({"a": [11, 41], "b": [21, 51], "timestamp": [31, 61]})
-    manager.write("test", data)
+    csv_data_store.write("test", data)
 
-    file_name = manager._create_file_path("test", 3, 61)
+    file_name = csv_data_store._create_file_path("test", 3, 61)
 
     data = pl.read_csv(file_name)
 
@@ -203,19 +203,22 @@ def test_write_append(tmpdir):
 
 
 def test_fill_with_zero():
-    manager = CSVDataStore("test")
-    assert manager._fill_with_zero(1, 10) == "0000000001"
-    assert manager._fill_with_zero(100) == "0000000100"
-    assert manager._fill_with_zero(1000) == "0000001000"
+    csv_data_store = CSVDataStore("test")
+    assert csv_data_store._fill_with_zero(1, 10) == "0000000001"
+    assert csv_data_store._fill_with_zero(100) == "0000000100"
+    assert csv_data_store._fill_with_zero(1000) == "0000001000"
 
 
 def test_get_to_value():
-    manager = CSVDataStore("test")
-    assert manager._get_to_value("test/test_from_0_to_0000000001.csv") == 1
-    assert manager._get_to_value("test/test_from_0_to_0000000005.csv") == 5
+    csv_data_store = CSVDataStore("test")
+    assert csv_data_store._get_to_value("test/test_from_0_to_0000000001.csv") == 1
+    assert csv_data_store._get_to_value("test/test_from_0_to_0000000005.csv") == 5
 
 
 def test_get_from_value():
-    manager = CSVDataStore("test")
-    assert manager._get_from_value("test/test_from_0000000001_to_0000000001.csv") == 1
-    assert manager._get_from_value("test/test_from_0000000005_to_.csv") == 5
+    csv_data_store = CSVDataStore("test")
+    assert (
+        csv_data_store._get_from_value("test/test_from_0000000001_to_0000000001.csv")
+        == 1
+    )
+    assert csv_data_store._get_from_value("test/test_from_0000000005_to_.csv") == 5

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -5,73 +5,70 @@ from pdr_backend.lake.persistent_data_store import (
 )  # Adjust the import based on your project structure
 
 
-# Initialize the PartitionedDataStore instance for testing
-def _get_test_manager(tmpdir):
+# Initialize the PersistentDataStore instance for testing
+def _get_persistent_data_store(tmpdir):
     example_df = pl.DataFrame(
         {"timestamp": ["2022-01-01", "2022-02-01", "2022-03-01"], "value": [10, 20, 30]}
     )
-    dataset_identifier = "test_df"
+    table_name = "test_df"
 
-    return [PersistentDataStore(str(tmpdir)), example_df, dataset_identifier]
+    return [PersistentDataStore(str(tmpdir)), example_df, table_name]
 
 
-def _clean_up_test_manager(tmpdir, dataset_identifier):
-    # Clean up the test manager
-    dataset_path = os.path.join(str(tmpdir), dataset_identifier)
-
-    persistent_ds_instance = PersistentDataStore(str(tmpdir))
-
-    view_name = persistent_ds_instance._generate_view_name(dataset_path)
+def _clean_up_persistent_data_store(tmpdir, table_name):
+    # Clean up PDS
+    persistent_data_store = PersistentDataStore(str(tmpdir))
 
     # Select tables from duckdb
-    views = persistent_ds_instance.duckdb_conn.execute(
+    views = persistent_data_store.duckdb_conn.execute(
         "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
     ).fetchall()
 
     # Drop the view and table
-    if view_name in [table[0] for table in views]:
-        persistent_ds_instance.duckdb_conn.execute(f"DROP TABLE {view_name}")
+    if table_name in [table[0] for table in views]:
+        persistent_data_store.duckdb_conn.execute(f"DROP TABLE {table_name}")
 
 
-def _check_view_exists(test_manager, dataset_identifier):
-    view_name = test_manager._generate_view_name(dataset_identifier)
-    tables = test_manager.duckdb_conn.execute(
+def _check_view_exists(persistent_data_store, table_name):
+    tables = persistent_data_store.duckdb_conn.execute(
         "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
     ).fetchall()
-    return [view_name in [table[0] for table in tables], view_name]
+    return [table_name in [table[0] for table in tables], table_name]
 
 
 def test_create_and_fill_table(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
 
-    test_manager._create_and_fill_table(example_df, dataset_identifier)
+    persistent_data_store._create_and_fill_table(example_df, table_name)
 
     # Check if the view is registered
-    assert _check_view_exists(test_manager, dataset_identifier)
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    assert _check_view_exists(persistent_data_store, table_name)
+    _clean_up_persistent_data_store(tmpdir, table_name)
 
 
 def test_insert_to_exist_table(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
 
-    test_manager._create_and_fill_table(example_df, dataset_identifier)
+    persistent_data_store._create_and_fill_table(example_df, table_name)
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(test_manager, dataset_identifier)
+    check_result, view_name = _check_view_exists(persistent_data_store, table_name)
     assert check_result
 
     # Insert new data to the table
     example_df = pl.DataFrame(
         {"timestamp": ["2022-04-01", "2022-05-01", "2022-06-01"], "value": [40, 50, 60]}
     )
-    test_manager.insert_to_table(example_df, dataset_identifier)
+    persistent_data_store.insert_to_table(example_df, table_name)
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(test_manager, dataset_identifier)
+    check_result, view_name = _check_view_exists(persistent_data_store, table_name)
     assert check_result
 
     # Check if the new data is inserted
-    result = test_manager.duckdb_conn.execute(f"SELECT * FROM {view_name}").fetchall()
+    result = persistent_data_store.duckdb_conn.execute(
+        f"SELECT * FROM {view_name}"
+    ).fetchall()
     assert len(result) == 6
     print(result)
     assert result[3][0] == "2022-04-01"
@@ -80,20 +77,22 @@ def test_insert_to_exist_table(tmpdir):
     assert result[4][1] == 50
     assert result[5][0] == "2022-06-01"
     assert result[5][1] == 60
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    _clean_up_persistent_data_store(tmpdir, table_name)
 
 
 def test_insert_to_new_table(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
 
-    test_manager.insert_to_table(example_df, dataset_identifier)
+    persistent_data_store.insert_to_table(example_df, table_name)
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(test_manager, dataset_identifier)
+    check_result, view_name = _check_view_exists(persistent_data_store, table_name)
     assert check_result
 
     # Check if the new data is inserted
-    result = test_manager.duckdb_conn.execute(f"SELECT * FROM {view_name}").fetchall()
+    result = persistent_data_store.duckdb_conn.execute(
+        f"SELECT * FROM {view_name}"
+    ).fetchall()
     assert len(result) == 3
     assert result[0][0] == "2022-01-01"
     assert result[0][1] == 10
@@ -101,60 +100,62 @@ def test_insert_to_new_table(tmpdir):
     assert result[1][1] == 20
     assert result[2][0] == "2022-03-01"
     assert result[2][1] == 30
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    _clean_up_persistent_data_store(tmpdir, table_name)
 
 
 def test_query_data(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
-    test_manager.insert_to_table(example_df, dataset_identifier)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
+    persistent_data_store.insert_to_table(example_df, table_name)
 
     # Check if the view is registered
-    check_result, _ = _check_view_exists(test_manager, dataset_identifier)
+    check_result, _ = _check_view_exists(persistent_data_store, table_name)
     assert check_result
 
     # Execute the provided SQL query
-    result_df = test_manager.query_data(
-        dataset_identifier, "SELECT * FROM {view_name} WHERE value > 15"
+    result_df = persistent_data_store.query_data(
+        f"SELECT * FROM {table_name} WHERE value > 15"
     )
     assert len(result_df) == 2, "Query did not return the expected number of rows."
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    _clean_up_persistent_data_store(tmpdir, table_name)
 
 
 def test_drop_table(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
 
-    test_manager.insert_to_table(example_df, dataset_identifier)
+    persistent_data_store.insert_to_table(example_df, table_name)
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(test_manager, dataset_identifier)
+    check_result, view_name = _check_view_exists(persistent_data_store, table_name)
     assert check_result
 
     # Drop the table
-    test_manager.drop_table(dataset_identifier, ds_type="table")
+    persistent_data_store.drop_table(table_name, ds_type="table")
 
     # Check if the view is dropped
-    tables = test_manager.duckdb_conn.execute(
+    tables = persistent_data_store.duckdb_conn.execute(
         "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
     ).fetchall()
     assert view_name not in [table[0] for table in tables]
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    _clean_up_persistent_data_store(tmpdir, table_name)
 
 
 def test_fill_from_csv_destination(tmpdir):
-    test_manager, example_df, dataset_identifier = _get_test_manager(tmpdir)
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
     csv_folder_path = os.path.join(str(tmpdir), "csv_folder")
     os.makedirs(csv_folder_path, exist_ok=True)
     example_df.write_csv(os.path.join(str(csv_folder_path), "data.csv"))
 
-    test_manager.fill_from_csv_destination(csv_folder_path, dataset_identifier)
+    persistent_data_store.fill_from_csv_destination(csv_folder_path, table_name)
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(test_manager, dataset_identifier)
+    check_result, view_name = _check_view_exists(persistent_data_store, table_name)
 
     assert check_result
 
     # Check if the new data is inserted
-    result = test_manager.duckdb_conn.execute(f"SELECT * FROM {view_name}").fetchall()
+    result = persistent_data_store.duckdb_conn.execute(
+        f"SELECT * FROM {view_name}"
+    ).fetchall()
     assert len(result) == 3
     assert result[0][0] == "2022-01-01"
     assert result[0][1] == 10
@@ -163,7 +164,7 @@ def test_fill_from_csv_destination(tmpdir):
     assert result[2][0] == "2022-03-01"
     assert result[2][1] == 30
 
-    _clean_up_test_manager(tmpdir, dataset_identifier)
+    _clean_up_persistent_data_store(tmpdir, table_name)
     # clean csv folder
     # delete files in the folder
     for file in os.listdir(csv_folder_path):

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -264,9 +264,7 @@ def test_append_to_db(tmpdir):
 
     table._append_to_db(pl.DataFrame([mocked_object] * 1000, schema=table_df_schema))
 
-    result = table.persistent_data_store.query_data(
-        table.table_name, "SELECT * FROM {view_name}"
-    )
+    result = table.persistent_data_store.query_data(f"SELECT * FROM {table.table_name}")
 
     assert result["ID"][0] == "0x123"
     assert result["pair"][0] == "ADA-USDT"


### PR DESCRIPTION
Fixes #756 

Changes proposed in this PR:
- [x] Removed black-box functionality around generate_view_name
- [x] Updated tests and verified that this is working as expected, by being able to directly query table names by their natural names (not a hash)
- [x] Future temporary/system-level tables should manage their own needs, such as adding a `_etl_build` prefix while ETL is building new tables to be joined w/ the live/production tables (with their natural names).