### PR TITLE
Fix #772 - TableRegistry Implementation

### DIFF
--- a/pdr_backend/accuracy/app.py
+++ b/pdr_backend/accuracy/app.py
@@ -127,9 +127,9 @@ def aggregate_statistics(
         and the total counts of correct predictions and slots evaluated.
     """
 
-    total_staked_yesterday = (
-        total_staked_today
-    ) = total_correct_predictions = total_slots_evaluated = 0
+    total_staked_yesterday = total_staked_today = total_correct_predictions = (
+        total_slots_evaluated
+    ) = 0
     for slot in slots:
         slot_results = process_single_slot(slot, end_of_previous_day_timestamp)
         if slot_results:

--- a/pdr_backend/accuracy/app.py
+++ b/pdr_backend/accuracy/app.py
@@ -127,9 +127,9 @@ def aggregate_statistics(
         and the total counts of correct predictions and slots evaluated.
     """
 
-    total_staked_yesterday = total_staked_today = total_correct_predictions = (
-        total_slots_evaluated
-    ) = 0
+    total_staked_yesterday = (
+        total_staked_today
+    ) = total_correct_predictions = total_slots_evaluated = 0
     for slot in slots:
         slot_results = process_single_slot(slot, end_of_previous_day_timestamp)
         if slot_results:

--- a/pdr_backend/accuracy/test/test_app.py
+++ b/pdr_backend/accuracy/test/test_app.py
@@ -25,7 +25,6 @@ SAMPLE_PREDICT_SLOT = PredictSlot(
 
 @enforce_types
 def test_calculate_prediction_result():
-
     # Test the calculate_prediction_prediction_result function with expected inputs
     result = calculate_prediction_result(150.0, 200.0)
     assert result

--- a/pdr_backend/aimodel/aimodel.py
+++ b/pdr_backend/aimodel/aimodel.py
@@ -4,7 +4,6 @@ import numpy as np
 
 @enforce_types
 class Aimodel:
-
     def __init__(self, skm, scaler, imps: np.ndarray):
         self._skm = skm  # sklearn model
         self._scaler = scaler  # for scaling X-inputs

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -24,8 +24,16 @@ class ETL:
 
     def __init__(self, ppss: PPSS, gql_data_factory: GQLDataFactory):
         self.ppss = ppss
-
         self.gql_data_factory = gql_data_factory
+
+        TableRegistry().register_table(
+            bronze_pdr_predictions_table_name,
+            (
+                bronze_pdr_predictions_table_name,
+                bronze_pdr_predictions_schema,
+                self.ppss,
+            ),
+        )
 
     def do_etl(self):
         """
@@ -70,14 +78,7 @@ class ETL:
             Update bronze_pdr_predictions table
         """
         print("update_bronze_pdr_predictions - Update bronze_pdr_predictions table.")
-        table = TableRegistry().register_table(
-            bronze_pdr_predictions_table_name,
-            (
-                bronze_pdr_predictions_table_name,
-                bronze_pdr_predictions_schema,
-                self.ppss,
-            ),
-        )
-
         data = get_bronze_pdr_predictions_data_with_SQL(self.ppss)
-        table.append_to_storage(data)
+        TableRegistry().get_table(bronze_pdr_predictions_table_name).append_to_storage(
+            data
+        )

--- a/pdr_backend/lake/table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/table_bronze_pdr_predictions.py
@@ -2,7 +2,7 @@ import polars as pl
 from polars import Boolean, Float64, Int64, Utf8
 
 from pdr_backend.ppss.ppss import PPSS
-from pdr_backend.lake.table_registry import TableRegistry
+from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 bronze_pdr_predictions_table_name = "bronze_pdr_predictions"
 
@@ -31,9 +31,9 @@ def get_bronze_pdr_predictions_data_with_SQL(ppss: PPSS) -> pl.DataFrame:
         Get the bronze pdr predictions data
     """
     # get the table
-    table = TableRegistry().get_table(bronze_pdr_predictions_table_name)
+    PDS = PersistentDataStore(ppss.lake_ss.parquet_dir)
 
-    return table.PDS.query_data(
+    return PDS.query_data(
         f"""
         SELECT 
             pdr_predictions.ID as ID,

--- a/pdr_backend/lake/table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/table_bronze_pdr_predictions.py
@@ -1,9 +1,8 @@
 import polars as pl
 from polars import Boolean, Float64, Int64, Utf8
 
-from pdr_backend.lake.table import Table
 from pdr_backend.ppss.ppss import PPSS
-
+from pdr_backend.lake.table_registry import TableRegistry
 
 bronze_pdr_predictions_table_name = "bronze_pdr_predictions"
 
@@ -32,9 +31,7 @@ def get_bronze_pdr_predictions_data_with_SQL(ppss: PPSS) -> pl.DataFrame:
         Get the bronze pdr predictions data
     """
     # get the table
-    table = Table(
-        bronze_pdr_predictions_table_name, bronze_pdr_predictions_schema, ppss
-    )
+    table = TableRegistry().get_table(bronze_pdr_predictions_table_name)
 
     return table.PDS.query_data(
         f"""

--- a/pdr_backend/lake/table_registry.py
+++ b/pdr_backend/lake/table_registry.py
@@ -1,0 +1,50 @@
+from typing import Optional, Dict, Tuple, List
+from polars.type_aliases import SchemaDict
+from enforce_typing import enforce_types
+
+from pdr_backend.ppss.ppss import PPSS
+from pdr_backend.lake.table import Table
+
+
+class TableRegistry:
+    _instance: Optional["TableRegistry"] = None
+    _tables: Dict[str, Table] = {}
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(TableRegistry, cls).__new__(cls)
+        return cls._instance
+
+    @enforce_types
+    def register_table(self, table_name: str, table_args: Tuple[str, SchemaDict, PPSS]):
+        if table_name in self._tables:
+            pass
+        self._tables[table_name] = Table(*table_args)
+        return self._tables[table_name]
+
+    @enforce_types
+    def register_tables(self, tables: Dict[str, Tuple[str, SchemaDict, PPSS]]):
+        for table_name, table_args in tables.items():
+            self.register_table(table_name, table_args)
+
+    @enforce_types
+    def get_table(self, table_name: str):
+        return self._tables.get(table_name)
+
+    @enforce_types
+    def get_tables(self, table_names: Optional[List] = None):
+        if table_names is None:
+            table_names = list(self._tables.keys())
+
+        target_tables = [self._tables.get(table_name) for table_name in table_names]
+
+        # do it this way to avoid returning None
+        target_tables = [table for table in target_tables if table is not None]
+
+        # do it a dictionary to preserve order
+        return dict(zip(table_names, target_tables))
+
+    @enforce_types
+    def unregister_table(self, table_name):
+        self._tables.pop(table_name, None)
+        return True

--- a/pdr_backend/lake/table_registry.py
+++ b/pdr_backend/lake/table_registry.py
@@ -48,3 +48,8 @@ class TableRegistry:
     def unregister_table(self, table_name):
         self._tables.pop(table_name, None)
         return True
+
+    @enforce_types
+    def clear_tables(self):
+        self._tables = {}
+        return True

--- a/pdr_backend/lake/test/resources.py
+++ b/pdr_backend/lake/test/resources.py
@@ -14,6 +14,7 @@ from pdr_backend.ppss.predictoor_ss import PredictoorSS, predictoor_ss_test_dict
 from pdr_backend.ppss.lake_ss import LakeSS
 from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.ppss.web3_pp import mock_web3_pp
+from pdr_backend.lake.table_registry import TableRegistry
 
 
 @enforce_types
@@ -31,6 +32,11 @@ def _lake_ss_1feed(tmpdir, feed, st_timestr=None, fin_timestr=None):
     ss = _lake_ss(parquet_dir, [feed], st_timestr, fin_timestr)
     ohlcv_data_factory = OhlcvDataFactory(ss)
     return ss, ohlcv_data_factory
+
+
+@enforce_types
+def _clean_up_table_registry():
+    TableRegistry()._tables = {}
 
 
 @enforce_types

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -13,6 +13,7 @@ from pdr_backend.lake.table_pdr_predictions import (
 from pdr_backend.lake.table_pdr_truevals import truevals_schema, truevals_table_name
 from pdr_backend.lake.table_pdr_payouts import payouts_schema, payouts_table_name
 from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
+from pdr_backend.lake.table_registry import TableRegistry
 
 # ETL code-coverage
 # Step 1. ETL -> do_sync_step()
@@ -84,15 +85,10 @@ def test_setup_etl(
 
     assert etl is not None
     assert etl.gql_data_factory == gql_data_factory
-    assert len(etl.tables) == 0
-
-    # Work 2: Complete ETL sync step - Assert 3 gql_dfs
-    etl.do_sync_step()
 
     pds_instance = _get_test_PDS(tmpdir)
 
     # Assert original gql has 6 predictions, but we only got 5 due to date
-    assert len(etl.tables) == 3
     pdr_predictions_df = pds_instance.query_data("SELECT * FROM pdr_predictions")
     assert len(pdr_predictions_df) == 5
     assert len(_gql_datafactory_etl_predictions_df) == 6
@@ -110,6 +106,7 @@ def test_setup_etl(
     assert len(pdr_payouts_df) == 4
     assert len(pdr_predictions_df) == 5
     assert len(pdr_truevals_df) == 5
+    assert len(TableRegistry().get_tables()) == 4
 
 
 @enforce_types
@@ -158,9 +155,6 @@ def test_etl_do_bronze_step(
 
     # Work 1: Initialize ETL
     etl = ETL(ppss, gql_data_factory)
-
-    # Work 2: Do sync
-    etl.do_sync_step()
 
     pds_instance = _get_test_PDS(tmpdir)
     pdr_predictions_records = pds_instance.query_data(

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -14,6 +14,7 @@ from pdr_backend.lake.table_pdr_truevals import truevals_schema, truevals_table_
 from pdr_backend.lake.table_pdr_payouts import payouts_schema, payouts_table_name
 from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
 from pdr_backend.lake.table_registry import TableRegistry
+from pdr_backend.lake.test.resources import _clean_up_table_registry
 
 # ETL code-coverage
 # Step 1. ETL -> do_sync_step()
@@ -41,6 +42,7 @@ def test_setup_etl(
     tmpdir,
 ):
     _clean_up_persistent_data_store(tmpdir)
+    _clean_up_table_registry()
 
     # setup test start-end date
     st_timestr = "2023-11-02_0:00"
@@ -120,6 +122,8 @@ def test_etl_do_bronze_step(
     tmpdir,
 ):
     _clean_up_persistent_data_store(tmpdir)
+    _clean_up_table_registry()
+
     # please note date, including Nov 1st
     st_timestr = "2023-11-01_0:00"
     fin_timestr = "2023-11-07_0:00"

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -108,7 +108,7 @@ def test_setup_etl(
     assert len(pdr_payouts_df) == 4
     assert len(pdr_predictions_df) == 5
     assert len(pdr_truevals_df) == 5
-    assert len(TableRegistry().get_tables()) == 4
+    assert len(TableRegistry().get_tables()) == 5
 
 
 @enforce_types
@@ -167,6 +167,7 @@ def test_etl_do_bronze_step(
         """
     )
     assert len(pdr_predictions_records) == 6
+
     # Work 3: Do bronze
     etl.do_bronze_step()
 

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -5,12 +5,15 @@ from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.lake.gql_data_factory import GQLDataFactory
 from pdr_backend.util.time_types import UnixTimeMs
 from pdr_backend.lake.table_registry import TableRegistry
+from pdr_backend.lake.test.resources import _clean_up_table_registry
 
 
 def test_gql_data_factory():
     """
     Test GQLDataFactory initialization
     """
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
     ppss = mock_ppss(
@@ -32,6 +35,8 @@ def test_update(_mock_fetch_gql, tmpdir):
     """
     Test GQLDataFactory update calls the update function for all the tables
     """
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
     ppss = mock_ppss(
@@ -67,6 +72,8 @@ def test_update_data(_mock_fetch_gql, _clean_up_test_folder, tmpdir):
     Test GQLDataFactory update calls the update function for all the tables
     """
     _clean_up_test_folder(tmpdir)
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
     ppss = mock_ppss(
@@ -101,6 +108,8 @@ def test_load_data(_mock_fetch_gql, _clean_up_test_folder, tmpdir):
     Test GQLDataFactory update calls the getting the data from tables
     """
     _clean_up_test_folder(tmpdir)
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
     ppss = mock_ppss(
@@ -137,6 +146,7 @@ def test_get_gql_tables(mock_update):
     Test GQLDataFactory's get_gql_tablesreturns all the tables
     """
     mock_update.return_value = None
+    _clean_up_table_registry()
 
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
@@ -159,6 +169,8 @@ def test_calc_start_ut(tmpdir):
     """
     Test GQLDataFactory's calc_start_ut returns the correct UnixTimeMs
     """
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2024-12-05"
     ppss = mock_ppss(
@@ -181,6 +193,8 @@ def test_do_subgraph_fetch(
     _clean_up_test_folder,
     tmpdir,
 ):
+    _clean_up_table_registry()
+
     st_timestr = "2023-12-03"
     fin_timestr = "2023-12-05"
     ppss = mock_ppss(

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -15,6 +15,7 @@ from pdr_backend.lake.table_bronze_pdr_predictions import (
 from pdr_backend.lake.table import Table
 from pdr_backend.lake.table_pdr_truevals import truevals_schema, truevals_table_name
 from pdr_backend.lake.table_pdr_payouts import payouts_schema, payouts_table_name
+from pdr_backend.lake.test.resources import _clean_up_table_registry
 
 
 @enforce_types
@@ -24,6 +25,8 @@ def test_table_bronze_pdr_predictions(
     _gql_datafactory_etl_truevals_df,
     tmpdir,
 ):
+    _clean_up_table_registry()
+
     # please note date, including Nov 1st
     st_timestr = "2023-11-01_0:00"
     fin_timestr = "2023-11-07_0:00"

--- a/pdr_backend/lake/test/test_table_registry.py
+++ b/pdr_backend/lake/test/test_table_registry.py
@@ -1,9 +1,6 @@
 from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.ppss.ppss import mock_ppss
-
-
-def _clean_up_table_registry():
-    TableRegistry()._tables = {}
+from pdr_backend.lake.test.resources import _clean_up_table_registry
 
 
 def _get_mock_ppss():
@@ -17,15 +14,18 @@ def _get_mock_ppss():
 
 
 def test_table_registry():
+    _clean_up_table_registry()
+
     TableRegistry().register_table(
         "test_table", ("test_table", {"test": "test"}, _get_mock_ppss())
     )
     assert len(TableRegistry().get_tables()) == 1
     assert TableRegistry()._tables["test_table"].table_name == "test_table"
-    _clean_up_table_registry()
 
 
 def test_register_tables():
+    _clean_up_table_registry()
+
     test_tables = {
         "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
         "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
@@ -35,18 +35,20 @@ def test_register_tables():
     assert len(TableRegistry().get_tables()) == 2
     assert TableRegistry()._tables["test_table"].table_name == "test_table"
     assert TableRegistry()._tables["test_table2"].table_name == "test_table2"
-    _clean_up_table_registry()
 
 
 def test_get_table():
+    _clean_up_table_registry()
+
     TableRegistry().register_table(
         "test_table", ("test_table", {"test": "test"}, _get_mock_ppss())
     )
     assert TableRegistry().get_table("test_table").table_name == "test_table"
-    _clean_up_table_registry()
 
 
 def test_get_tables():
+    _clean_up_table_registry()
+
     test_tables = {
         "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
         "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
@@ -62,10 +64,11 @@ def test_get_tables():
         TableRegistry().get_tables(["test_table2"])["test_table2"].table_name
         == "test_table2"
     )
-    _clean_up_table_registry()
 
 
 def test_clear_tables():
+    _clean_up_table_registry()
+
     test_tables = {
         "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
         "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
@@ -75,4 +78,3 @@ def test_clear_tables():
     assert len(TableRegistry().get_tables()) == 2
     TableRegistry().clear_tables()
     assert len(TableRegistry().get_tables()) == 0
-    _clean_up_table_registry()

--- a/pdr_backend/lake/test/test_table_registry.py
+++ b/pdr_backend/lake/test/test_table_registry.py
@@ -1,0 +1,65 @@
+from pdr_backend.lake.table_registry import TableRegistry
+from pdr_backend.ppss.ppss import mock_ppss
+
+
+def _clean_up_table_registry():
+    TableRegistry()._tables = {}
+
+
+def _get_mock_ppss():
+    return mock_ppss(
+        ["binance BTC/USDT c 5m"],
+        "sapphire-mainnet",
+        ".",
+        st_timestr="2023-12-03",
+        fin_timestr="2024-12-05",
+    )
+
+
+def test_table_registry():
+    TableRegistry().register_table(
+        "test_table", ("test_table", {"test": "test"}, _get_mock_ppss())
+    )
+    assert len(TableRegistry().get_tables()) == 1
+    assert TableRegistry()._tables["test_table"].table_name == "test_table"
+    _clean_up_table_registry()
+
+
+def test_register_tables():
+    test_tables = {
+        "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
+        "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
+    }
+
+    TableRegistry().register_tables(test_tables)
+    assert len(TableRegistry().get_tables()) == 2
+    assert TableRegistry()._tables["test_table"].table_name == "test_table"
+    assert TableRegistry()._tables["test_table2"].table_name == "test_table2"
+    _clean_up_table_registry()
+
+
+def test_get_table():
+    TableRegistry().register_table(
+        "test_table", ("test_table", {"test": "test"}, _get_mock_ppss())
+    )
+    assert TableRegistry().get_table("test_table").table_name == "test_table"
+    _clean_up_table_registry()
+
+
+def test_get_tables():
+    test_tables = {
+        "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
+        "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
+    }
+
+    TableRegistry().register_tables(test_tables)
+    assert len(TableRegistry().get_tables()) == 2
+    assert (
+        TableRegistry().get_tables(["test_table"])["test_table"].table_name
+        == "test_table"
+    )
+    assert (
+        TableRegistry().get_tables(["test_table2"])["test_table2"].table_name
+        == "test_table2"
+    )
+    _clean_up_table_registry()

--- a/pdr_backend/lake/test/test_table_registry.py
+++ b/pdr_backend/lake/test/test_table_registry.py
@@ -63,3 +63,16 @@ def test_get_tables():
         == "test_table2"
     )
     _clean_up_table_registry()
+
+
+def test_clear_tables():
+    test_tables = {
+        "test_table": ("test_table", {"test": "test"}, _get_mock_ppss()),
+        "test_table2": ("test_table2", {"test": "test"}, _get_mock_ppss()),
+    }
+
+    TableRegistry().register_tables(test_tables)
+    assert len(TableRegistry().get_tables()) == 2
+    TableRegistry().clear_tables()
+    assert len(TableRegistry().get_tables()) == 0
+    _clean_up_table_registry()

--- a/pdr_backend/predictoor/test/test_predictoor_agent.py
+++ b/pdr_backend/predictoor/test/test_predictoor_agent.py
@@ -167,7 +167,6 @@ def test_predictoor_agent_calc_stakes2_1feed(tmpdir, monkeypatch):
     with patch(f"{d}.PredictoorAgent.get_ohlcv_data", mock_get_ohlcv_data2), patch(
         f"{d}.AimodelFactory.build", mock_build
     ):
-
         # initialize agent
         _, ppss, _ = mock_ppss_1feed(2, str(tmpdir), monkeypatch)
         aimodel_ss = ppss.predictoor_ss.aimodel_ss
@@ -205,7 +204,6 @@ def test_predictoor_agent_calc_stakes2_2feeds(tmpdir, monkeypatch):
     with patch(f"{d}.PredictoorAgent.get_ohlcv_data", mock_get_ohlcv_data2), patch(
         f"{d}.AimodelFactory.build", mock_build
     ):
-
         # initialize agent
         feeds, ppss = mock_ppss_2feeds(2, str(tmpdir), monkeypatch)
         assert ppss.predictoor_ss.approach == 2

--- a/pdr_backend/subgraph/subgraph_payout.py
+++ b/pdr_backend/subgraph/subgraph_payout.py
@@ -117,7 +117,6 @@ def fetch_payouts(
     skip: int,
     network: str = "mainnet",
 ) -> List[Payout]:
-
     payouts: List[Payout] = []
 
     query = get_payout_query(

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 # Installed by pip install pdr-backend
 # or pip install -e .
 install_requirements = [
+    "black==24.2.0",
     "bumpversion",
     "ccxt>=4.1.59",
     "coverage",


### PR DESCRIPTION
Fixes #772 

Changes proposed in this PR:

- ***TableRegistry Singleton:*** A new file `table_registry.py` has been added. This file defines the `TableRegistry` singleton, which manages access to the table objects.

- ***Refactor ETL Process:*** The `etl.py` file has been modified to use the `TableRegistry` singleton instead of directly accessing `record_config[tables]`. This centralizes the table management and makes the ETL process cleaner and more maintainable.

- ***Refactor GQLDataFactory:*** The `gql_data_factory.py` file has been modified to work with the new `TableRegistry` singleton.

- ***Refactor Bronze Table:*** The `table_bronze_pdr_predictions.py` file has been modified to register itself with the TableRegistry singleton.

- ***Unit Tests:*** New unit tests have been added in test_table_registry.py to ensure the correct functionality of the `TableRegistry` singleton. Existing tests in `test_gql_data_factory.py` have been updated to work with the new `TableRegistry` singleton.