### PR TITLE
Fixes #784 - Query pending payouts - Get canceled slots

### DIFF
--- a/pdr_backend/subgraph/subgraph_pending_payouts.py
+++ b/pdr_backend/subgraph/subgraph_pending_payouts.py
@@ -21,7 +21,7 @@ def query_pending_payouts(subgraph_url: str, addr: str) -> Dict[str, List[UnixTi
         query = """
         {
                 predictPredictions(
-                    where: {user: "%s", payout: null, slot_: {status_not: "Pending"} }, first: %s, skip: %s
+                    where: {user: "%s", payout: null, slot_: {status_in: ["Paying", "Canceled"]} }, first: %s, skip: %s
                 ) {
                     id
                     timestamp


### PR DESCRIPTION
Fixes #784

Changes proposed in this PR:

- Query pending payouts: Get **canceled** and paying slots