### PR TITLE
Fix #771 - Temp Table Logic for the build step and the bronze step start/finish parameter calculations

### DIFF
--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -14,6 +14,8 @@ from pdr_backend.lake.table_pdr_predictions import predictions_table_name
 from pdr_backend.lake.table_pdr_subscriptions import subscriptions_table_name
 from pdr_backend.lake.table_pdr_truevals import truevals_table_name
 from pdr_backend.lake.plutil import get_table_name
+
+
 class ETL:
     """
     @description
@@ -44,7 +46,7 @@ class ETL:
             payouts_table_name,
             predictions_table_name,
             subscriptions_table_name,
-            truevals_table_name
+            truevals_table_name,
         ]
 
     def _check_build_sql_tables(self):

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -83,6 +83,10 @@ class ETL:
         print("do_etl - Start ETL.")
 
         try:
+            # Check if the SQL tables exist and drop them if they do
+            self._check_build_sql_tables()
+            print("do_etl - Checked build tables.")
+
             # Sync data
             self.gql_data_factory.get_gql_tables()
             print("do_etl - Synced data.")

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -57,7 +57,7 @@ class ETL:
 
         self.build_table_names = [*self.bronze_table_names, *self.raw_table_names]
 
-    def _check_build_sql_tables(self):
+    def _drop_build_sql_tables(self):
         """
         @description
             Check if the SQL tables are built
@@ -93,21 +93,21 @@ class ETL:
         print("do_etl - Start ETL.")
 
         try:
-            # Check if the SQL tables exist and drop them if they do
-            self._check_build_sql_tables()
-            print("do_etl - Checked build tables.")
+            # Drop any build tables if they already exist
+            self._drop_build_sql_tables()
+            print("do_etl - Drop build tables.")
 
             # Sync data
             self.gql_data_factory.get_gql_tables()
-            print("do_etl - Synced data.")
+            print("do_etl - Synced data. Start bronze_step.")
 
             self.do_bronze_step()
 
             end_ts = time.time_ns() / 1e9
-            print(f"do_etl - Completed in {end_ts - st_ts} sec.")
+            print(f"do_etl - Completed bronze_step in {end_ts - st_ts} sec.")
 
             self._move_build_tables_to_permanent()
-            print("do_etl - Moved build tables to permanent tables.")
+            print("do_etl - Moved build tables to permanent tables. ETL Complete.")
         except Exception as e:
             print(f"Error when executing ETL: {e}")
 
@@ -203,7 +203,7 @@ class ETL:
         )
 
         print(f"update_bronze_pdr_predictions - data: {data}")
-        TableRegistry().get_table(bronze_pdr_predictions_table_name).append_to_storage(
+        TableRegistry().get_table(bronze_pdr_predictions_table_name)._append_to_db(
             data,
             build_mode=True,
         )

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -192,9 +192,6 @@ class ETL:
         """
         print("update_bronze_pdr_predictions - Update bronze_pdr_predictions table.")
         st_timestamp, fin_timestamp = self._calc_bronze_start_end_ts()
-        print(
-            f"update_bronze_pdr_predictions - st_timestamp: {st_timestamp}, fin_timestamp: {fin_timestamp}"
-        )
 
         data = get_bronze_pdr_predictions_data_with_SQL(
             path=self.ppss.lake_ss.parquet_dir,

--- a/pdr_backend/lake/persistent_data_store.py
+++ b/pdr_backend/lake/persistent_data_store.py
@@ -114,9 +114,10 @@ class PersistentDataStore(BaseDataStore):
         if temp_table_name in [table[0] for table in tables]:
             # check if the permanent table exists
             if permanent_table_name not in [table[0] for table in tables]:
-                #create table if it does not exist
+                # create table if it does not exist
                 self.duckdb_conn.execute(
-                    f"CREATE TABLE {permanent_table_name} AS SELECT * FROM {temp_table_name}")
+                    f"CREATE TABLE {permanent_table_name} AS SELECT * FROM {temp_table_name}"
+                )
             else:
                 # Move the data from the temporary table to the permanent table
                 self.duckdb_conn.execute(

--- a/pdr_backend/lake/persistent_data_store.py
+++ b/pdr_backend/lake/persistent_data_store.py
@@ -1,8 +1,8 @@
 # The PersistentDataStore class is a subclass of the Base
 import os
 import glob
-import duckdb
 from typing import Optional
+import duckdb
 
 from enforce_typing import enforce_types
 import polars as pl
@@ -42,6 +42,20 @@ class PersistentDataStore(BaseDataStore):
         self.duckdb_conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM df")
 
     @enforce_types
+    def get_table_names(self):
+        """
+        Get the names of all tables from duckdb main schema.
+        @returns:
+            list - The names of the tables in the dataset.
+        """
+
+        tables = self.duckdb_conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+        ).fetchall()
+
+        return [table[0] for table in tables]
+
+    @enforce_types
     def insert_to_table(self, df: pl.DataFrame, table_name: str):
         """
         Insert data to an persistent dataset.
@@ -58,11 +72,9 @@ class PersistentDataStore(BaseDataStore):
         """
 
         # Check if the table exists
-        tables = self.duckdb_conn.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-        ).fetchall()
+        table_names = self.get_table_names()
 
-        if table_name in [table[0] for table in tables]:
+        if table_name in table_names:
             self.duckdb_conn.execute(f"INSERT INTO {table_name} SELECT * FROM df")
         else:
             self._create_and_fill_table(df, table_name)
@@ -86,8 +98,7 @@ class PersistentDataStore(BaseDataStore):
         except duckdb.CatalogException as e:
             if "Table" in str(e) and "not exist" in str(e):
                 return None
-            else:
-                raise e
+            raise e
 
     @enforce_types
     def drop_table(self, table_name: str):
@@ -114,13 +125,11 @@ class PersistentDataStore(BaseDataStore):
         """
 
         # Check if the table exists
-        tables = self.duckdb_conn.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-        ).fetchall()
+        table_names = self.get_table_names()
 
-        if temp_table_name in [table[0] for table in tables]:
+        if temp_table_name in table_names:
             # check if the permanent table exists
-            if permanent_table_name not in [table[0] for table in tables]:
+            if permanent_table_name not in table_names:
                 # create table if it does not exist
                 self.duckdb_conn.execute(
                     f"CREATE TABLE {permanent_table_name} AS SELECT * FROM {temp_table_name}"

--- a/pdr_backend/lake/plutil.py
+++ b/pdr_backend/lake/plutil.py
@@ -266,10 +266,11 @@ def filter_and_drop_columns(
     """
     return df.filter(pl.col(target_column).is_in(ids)).drop(columns_to_drop)
 
+
 @enforce_types
 def get_table_name(table_name: str, build_mode: bool = False) -> str:
     """
-        Get the table name with the build mode prefix
+    Get the table name with the build mode prefix
     """
     if build_mode:
         return f"_build_{table_name}"

--- a/pdr_backend/lake/plutil.py
+++ b/pdr_backend/lake/plutil.py
@@ -265,3 +265,12 @@ def filter_and_drop_columns(
         Modified dataframe
     """
     return df.filter(pl.col(target_column).is_in(ids)).drop(columns_to_drop)
+
+@enforce_types
+def get_table_name(table_name: str, build_mode: bool = False) -> str:
+    """
+        Get the table name with the build mode prefix
+    """
+    if build_mode:
+        return f"_build_{table_name}"
+    return table_name

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -20,7 +20,7 @@ class Table:
         self.df_schema = df_schema
 
         self.base_path = self.ppss.lake_ss.parquet_dir
-        
+
     @enforce_types
     def append_to_storage(self, data: pl.DataFrame, build_mode: bool = False):
         self._append_to_csv(data)
@@ -55,9 +55,7 @@ class Table:
         table_name = get_table_name(self.table_name, build_mode)
         PersistentDataStore(self.base_path).insert_to_table(data, table_name)
         n_new = data.shape[0]
-        print(
-            f"  Just saved df with {n_new} df rows to the database of {table_name}"
-        )
+        print(f"  Just saved df with {n_new} df rows to the database of {table_name}")
 
     def get_pds_last_record(self) -> Optional[pl.DataFrame]:
         """

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -7,6 +7,7 @@ from enforce_typing import enforce_types
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
+from pdr_backend.lake.plutil import get_table_name
 
 logger = logging.getLogger("table")
 
@@ -19,11 +20,11 @@ class Table:
         self.df_schema = df_schema
 
         self.base_path = self.ppss.lake_ss.parquet_dir
-
+        
     @enforce_types
-    def append_to_storage(self, data: pl.DataFrame):
+    def append_to_storage(self, data: pl.DataFrame, build_mode: bool = False):
         self._append_to_csv(data)
-        self._append_to_db(data)
+        self._append_to_db(data, build_mode)
 
     @enforce_types
     def _append_to_csv(self, data: pl.DataFrame):
@@ -43,7 +44,7 @@ class Table:
         )
 
     @enforce_types
-    def _append_to_db(self, data: pl.DataFrame):
+    def _append_to_db(self, data: pl.DataFrame, build_mode: bool = False):
         """
         Append the data from the DataFrame object into the database
         It only saves the new data that has been fetched
@@ -51,10 +52,11 @@ class Table:
         @arguments:
             data - The Polars DataFrame to save.
         """
-        PersistentDataStore(self.base_path).insert_to_table(data, self.table_name)
+        table_name = get_table_name(self.table_name, build_mode)
+        PersistentDataStore(self.base_path).insert_to_table(data, table_name)
         n_new = data.shape[0]
         print(
-            f"  Just saved df with {n_new} df rows to the database of {self.table_name}"
+            f"  Just saved df with {n_new} df rows to the database of {table_name}"
         )
 
     def get_pds_last_record(self) -> Optional[pl.DataFrame]:

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -372,14 +372,12 @@ def _clean_up_persistent_data_store(tmpdir, table_name=None):
     persistent_data_store = PersistentDataStore(str(tmpdir))
 
     # Select tables from duckdb
-    views = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
+    table_names = persistent_data_store.get_table_names()
 
     # Drop the view and table
-    if table_name in [table[0] for table in views]:
+    if table_name in table_names:
         persistent_data_store.duckdb_conn.execute(f"DROP TABLE {table_name}")
 
     if table_name is None:
-        for table in views:
-            persistent_data_store.duckdb_conn.execute(f"DROP TABLE {table[0]}")
+        for table in table_names:
+            persistent_data_store.duckdb_conn.execute(f"DROP TABLE {table}")

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -8,6 +8,7 @@ from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.lake.test.resources import _clean_up_table_registry
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
+
 def test_gql_data_factory():
     """
     Test GQLDataFactory initialization

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -6,7 +6,7 @@ from pdr_backend.lake.gql_data_factory import GQLDataFactory
 from pdr_backend.util.time_types import UnixTimeMs
 from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.lake.test.resources import _clean_up_table_registry
-
+from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 def test_gql_data_factory():
     """
@@ -96,7 +96,10 @@ def test_update_data(_mock_fetch_gql, _clean_up_test_folder, tmpdir):
 
     gql_data_factory._update()
 
-    last_record = TableRegistry().get_table("pdr_predictions").get_pds_last_record()
+    last_record = PersistentDataStore(ppss.lake_ss.parquet_dir).query_data(
+        "SELECT * FROM _build_pdr_predictions ORDER BY timestamp DESC LIMIT 1"
+    )
+
     assert last_record is not None
     assert len(last_record) > 0
     assert last_record["pair"][0] == "BTC/USDT"
@@ -132,7 +135,9 @@ def test_load_data(_mock_fetch_gql, _clean_up_test_folder, tmpdir):
 
     gql_data_factory._update()
 
-    all_reacords = TableRegistry().get_table("pdr_predictions").get_records()
+    all_reacords = PersistentDataStore(ppss.lake_ss.parquet_dir).query_data(
+        "SELECT * FROM _build_pdr_predictions"
+    )
 
     assert all_reacords is not None
     assert len(all_reacords) > 0

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -19,10 +19,8 @@ def _get_persistent_data_store(tmpdir):
 
 
 def _check_view_exists(persistent_data_store, table_name):
-    tables = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
-    return [table_name in [table[0] for table in tables], table_name]
+    table_names = persistent_data_store.get_table_names()
+    return [table_name in table_names, table_name]
 
 
 def test_create_and_fill_table(tmpdir):
@@ -121,10 +119,8 @@ def test_drop_table(tmpdir):
     persistent_data_store.drop_table(table_name)
 
     # Check if the view is dropped
-    tables = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
-    assert view_name not in [table[0] for table in tables]
+    table_names = persistent_data_store.get_table_names()
+    assert view_name not in table_names
     _clean_up_persistent_data_store(tmpdir, table_name)
 
 
@@ -250,14 +246,11 @@ def test_move_table_data(tmpdir):
     persistent_data_store.move_table_data(get_table_name(table_name, True), table_name)
 
     # Check if the view is dropped
-    tables = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
-
-    assert get_table_name(table_name, True) not in [table[0] for table in tables]
+    table_names = persistent_data_store.get_table_names()
+    assert get_table_name(table_name, True) not in table_names
 
     # Check if the new table is created
-    assert table_name in [table[0] for table in tables]
+    assert table_name in table_names
 
     # Check if the new data is inserted
     result = persistent_data_store.duckdb_conn.execute(

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -7,6 +7,7 @@ from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
 from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.plutil import get_table_name
 
+
 # Initialize the PersistentDataStore instance for testing
 def _get_persistent_data_store(tmpdir):
     example_df = pl.DataFrame(
@@ -233,12 +234,15 @@ def test__duckdb_connection(tmpdir):
 
     _clean_up_persistent_data_store(tmpdir)
 
+
 def test_move_table_data(tmpdir):
     persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
     persistent_data_store.insert_to_table(example_df, get_table_name(table_name, True))
 
     # Check if the view is registered
-    check_result, view_name = _check_view_exists(persistent_data_store, get_table_name(table_name, True))
+    check_result = _check_view_exists(
+        persistent_data_store, get_table_name(table_name, True)
+    )
 
     assert check_result
 

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -5,7 +5,7 @@ import duckdb
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
 from pdr_backend.lake.csv_data_store import CSVDataStore
-
+from pdr_backend.lake.plutil import get_table_name
 
 # Initialize the PersistentDataStore instance for testing
 def _get_persistent_data_store(tmpdir):
@@ -117,7 +117,7 @@ def test_drop_table(tmpdir):
     assert check_result
 
     # Drop the table
-    persistent_data_store.drop_table(table_name, ds_type="table")
+    persistent_data_store.drop_table(table_name)
 
     # Check if the view is dropped
     tables = persistent_data_store.duckdb_conn.execute(
@@ -232,3 +232,33 @@ def test__duckdb_connection(tmpdir):
     ), "The connection is not a DuckDBPyConnection"
 
     _clean_up_persistent_data_store(tmpdir)
+
+def test_move_table_data(tmpdir):
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
+    persistent_data_store.insert_to_table(example_df, get_table_name(table_name, True))
+
+    # Check if the view is registered
+    check_result, view_name = _check_view_exists(persistent_data_store, get_table_name(table_name, True))
+
+    assert check_result
+
+    # Move the table
+    persistent_data_store.move_table_data(get_table_name(table_name, True), table_name)
+
+    # Check if the view is dropped
+    tables = persistent_data_store.duckdb_conn.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+    ).fetchall()
+
+    assert get_table_name(table_name, True) not in [table[0] for table in tables]
+
+    # Check if the new table is created
+    assert table_name in [table[0] for table in tables]
+
+    # Check if the new data is inserted
+    result = persistent_data_store.duckdb_conn.execute(
+        f"SELECT * FROM {table_name}"
+    ).fetchall()
+
+    assert len(result) == 3
+    assert result[0][0] == "2022-01-01"

--- a/pdr_backend/lake/test/test_plutil.py
+++ b/pdr_backend/lake/test/test_plutil.py
@@ -22,7 +22,7 @@ from pdr_backend.lake.plutil import (
     save_rawohlcv_file,
     set_col_values,
     text_to_df,
-    get_table_name
+    get_table_name,
 )
 
 FOUR_ROWS_RAW_TOHLCV_DATA = [
@@ -305,6 +305,7 @@ def test_text_to_df():
     assert df["timestamp"][0] == 0
     assert df["open"][1] == 10.1
     assert isinstance(df["open"][1], float)
+
 
 @enforce_types
 def test_get_table_name():

--- a/pdr_backend/lake/test/test_plutil.py
+++ b/pdr_backend/lake/test/test_plutil.py
@@ -22,6 +22,7 @@ from pdr_backend.lake.plutil import (
     save_rawohlcv_file,
     set_col_values,
     text_to_df,
+    get_table_name
 )
 
 FOUR_ROWS_RAW_TOHLCV_DATA = [
@@ -304,3 +305,14 @@ def test_text_to_df():
     assert df["timestamp"][0] == 0
     assert df["open"][1] == 10.1
     assert isinstance(df["open"][1], float)
+
+@enforce_types
+def test_get_table_name():
+    table_name = get_table_name("test")
+    assert table_name == "test"
+
+    table_name = get_table_name("test", True)
+    assert table_name == "_build_test"
+
+    table_name = get_table_name("test", False)
+    assert table_name == "test"

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -11,10 +11,8 @@ from pdr_backend.lake.csv_data_store import CSVDataStore
 
 
 def _check_view_exists(persistent_data_store, table_name):
-    tables = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
-    return [table_name in [table[0] for table in tables], table_name]
+    table_names = persistent_data_store.get_table_names()
+    return [table_name in table_names, table_name]
 
 
 def _clean_up_persistent_data_store(tmpdir, table_name):
@@ -22,12 +20,10 @@ def _clean_up_persistent_data_store(tmpdir, table_name):
     persistent_data_store = PersistentDataStore(str(tmpdir))
 
     # Select tables from duckdb
-    views = persistent_data_store.duckdb_conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    ).fetchall()
+    table_names = persistent_data_store.get_table_names()
 
-    # Drop the view and table
-    if table_name in [table[0] for table in views]:
+    # Drop the table
+    if table_name in table_names:
         persistent_data_store.duckdb_conn.execute(f"DROP TABLE {table_name}")
 
 

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -15,6 +15,7 @@ from pdr_backend.lake.table_pdr_truevals import truevals_schema, truevals_table_
 from pdr_backend.lake.table_pdr_payouts import payouts_schema, payouts_table_name
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.test.resources import _clean_up_table_registry
+from pdr_backend.util.time_types import UnixTimeMs
 
 
 @enforce_types
@@ -63,7 +64,11 @@ def test_table_bronze_pdr_predictions(
     assert len(result_payouts) == 5
 
     # Work 2: Execute full SQL query
-    result = get_bronze_pdr_predictions_data_with_SQL(ppss)
+    result = get_bronze_pdr_predictions_data_with_SQL(
+        ppss.lake_ss.parquet_dir,
+        st_ms=UnixTimeMs.from_timestr(ppss.lake_ss.st_timestr),
+        fin_ms=UnixTimeMs.from_timestr(ppss.lake_ss.fin_timestr),
+    )
 
     # Final result should have 6 rows
     assert len(result) == 6

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -47,7 +47,9 @@ def test_table_bronze_pdr_predictions(
     }
 
     # Work 1: Append all data onto bronze_table
-    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df, True)
+    gql_tables["pdr_predictions"].append_to_storage(
+        _gql_datafactory_etl_predictions_df, True
+    )
     gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, True)
     gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, True)
 

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -47,17 +47,17 @@ def test_table_bronze_pdr_predictions(
     }
 
     # Work 1: Append all data onto bronze_table
-    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df)
-    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df)
-    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df)
+    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df, True)
+    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, True)
+    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, True)
 
     PDS = PersistentDataStore(ppss.lake_ss.parquet_dir)
     # truevals should have 6
-    result_truevals = PDS.query_data("SELECT * FROM pdr_truevals")
+    result_truevals = PDS.query_data("SELECT * FROM _build_pdr_truevals")
     assert len(result_truevals) == 6
 
     # payouts should have 6
-    result_payouts = PDS.query_data("SELECT * FROM pdr_payouts")
+    result_payouts = PDS.query_data("SELECT * FROM _build_pdr_payouts")
     assert len(result_payouts) == 5
 
     # Work 2: Execute full SQL query


### PR DESCRIPTION
Fixes #771 

Changes proposed in this PR:

- The data fetched during the build process is written to build tables.
- The logic to move the DB table after the build process has been developed.
- Some helpers and tests are added

PS: broken sync process on the ETL is fixed
