### PR TITLE
Fix #809 - Clean entire table queries

### DIFF
--- a/pdr_backend/analytics/test/test_get_predictions_info.py
+++ b/pdr_backend/analytics/test/test_get_predictions_info.py
@@ -12,9 +12,7 @@ table_name = "pdr_predictions"
 
 @enforce_types
 @patch("pdr_backend.analytics.get_predictions_info.get_feed_summary_stats")
-@patch("pdr_backend.analytics.get_predictions_info.GQLDataFactory.get_gql_tables")
 def test_get_predictions_info_main_mainnet(
-    mock_get_gql_tables,
     mock_get_feed_summary_stats,
     _gql_datafactory_first_predictions_df,
     tmpdir,
@@ -38,9 +36,8 @@ def test_get_predictions_info_main_mainnet(
     predictions_table = Table(table_name, predictions_df.schema, ppss)
     predictions_table.append_to_storage(predictions_df)
 
-    mock_get_gql_tables.return_value = {"pdr_predictions": predictions_table}
-
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
+
     get_predictions_info_main(
         ppss,
         st_timestr,
@@ -74,15 +71,12 @@ def test_get_predictions_info_main_mainnet(
     # data frame after filtering is same as manual filtered dataframe
     pl.DataFrame.equals(mock_get_feed_summary_stats.call_args, preds_df)
 
-    assert mock_get_gql_tables.call_count == 1
     assert mock_get_feed_summary_stats.call_count == 1
 
 
 @enforce_types
 @patch("pdr_backend.analytics.get_predictions_info.get_feed_summary_stats")
-@patch("pdr_backend.analytics.get_predictions_info.GQLDataFactory.get_gql_tables")
 def test_get_predictions_info_bad_date_range(
-    mock_get_gql_tables,
     get_feed_summary_stats,
     _gql_datafactory_first_predictions_df,
     tmpdir,
@@ -106,8 +100,6 @@ def test_get_predictions_info_bad_date_range(
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = Table(table_name, predictions_df.schema, ppss)
     predictions_table.append_to_storage(predictions_df)
-
-    mock_get_gql_tables.return_value = {"pdr_predictions": predictions_table}
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -134,15 +126,12 @@ def test_get_predictions_info_bad_date_range(
 
     assert len(preds_df) == 0
 
-    assert mock_get_gql_tables.call_count == 1
     assert get_feed_summary_stats.call_count == 0
 
 
 @enforce_types
 @patch("pdr_backend.analytics.get_predictions_info.get_feed_summary_stats")
-@patch("pdr_backend.analytics.get_predictions_info.GQLDataFactory.get_gql_tables")
 def test_get_predictions_info_bad_feed(
-    mock_get_gql_tables,
     mock_get_feed_summary_stats,
     _gql_datafactory_first_predictions_df,
     tmpdir,
@@ -167,8 +156,6 @@ def test_get_predictions_info_bad_feed(
     predictions_table = Table(table_name, predictions_df.schema, ppss)
     predictions_table.append_to_storage(predictions_df)
 
-    mock_get_gql_tables.return_value = {"pdr_predictions": predictions_table}
-
     feed_addr = "0x8e0we267779d27c2b3ed5408408ff15d9f3a3152"
 
     # wrong feed address will raise error because there will be no data to process
@@ -187,15 +174,11 @@ def test_get_predictions_info_bad_feed(
 
     assert len(predictions_df) == 0
 
-    assert mock_get_gql_tables.call_count == 1
     assert mock_get_feed_summary_stats.call_count == 0
 
 
 @enforce_types
-@patch("pdr_backend.analytics.get_predictions_info.GQLDataFactory.get_gql_tables")
-def test_get_predictions_info_empty(
-    mock_get_gql_tables, _gql_datafactory_first_predictions_df, tmpdir
-):
+def test_get_predictions_info_empty(_gql_datafactory_first_predictions_df, tmpdir):
     """
     @description
         assert data factory returns valid records before calculating stats
@@ -216,8 +199,6 @@ def test_get_predictions_info_empty(
 
     predictions_table = Table(table_name, {}, ppss)
     predictions_table.append_to_storage(pl.DataFrame([], schema=predictions_df.schema))
-    # mockt he gql data factory not having any records
-    mock_get_gql_tables.return_value = {"pdr_predictions": predictions_table}
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 import polars as pl
 from polars.type_aliases import SchemaDict
 
@@ -60,38 +59,3 @@ class Table:
         PersistentDataStore(self.base_path).insert_to_table(data, table_name)
         n_new = data.shape[0]
         print(f"  Just saved df with {n_new} df rows to the database of {table_name}")
-
-    def get_pds_last_record(self) -> Optional[pl.DataFrame]:
-        """
-        Get the last record from the persistent data store
-
-        @returns
-            pl.DataFrame
-        """
-
-        query = f"SELECT * FROM {self.table_name} ORDER BY timestamp DESC LIMIT 1"
-        try:
-            return PersistentDataStore(self.base_path).query_data(query)
-        except Exception as e:
-            print(f"Error fetching last record from PDS: {e}")
-            return None
-
-    @enforce_types
-    def get_records(
-        self,
-        source: Optional[str] = "db",
-    ) -> Optional[pl.DataFrame]:
-        """
-        Get the records from the persistent data store
-
-        @returns
-            pl.DataFrame
-        """
-        if source == "db":
-            return PersistentDataStore(self.base_path).query_data(
-                f"SELECT * FROM {self.table_name}"
-            )
-
-        return CSVDataStore(self.base_path).read_all(
-            self.table_name, schema=self.df_schema
-        )

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -147,31 +147,3 @@ def test_persistent_store(
     assert result["timeframe"][0] == "5m"
     assert result["predvalue"][0] is True
     assert len(result) == 8
-
-
-def test_get_records(tmpdir, _gql_datafactory_first_predictions_df):
-    st_timestr = "2023-12-03"
-    fin_timestr = "2024-12-05"
-    ppss = mock_ppss(
-        ["binance BTC/USDT c 5m"],
-        "sapphire-mainnet",
-        str(tmpdir),
-        st_timestr=st_timestr,
-        fin_timestr=fin_timestr,
-    )
-
-    table = Table(predictions_table_name, predictions_schema, ppss)
-
-    PDS = PersistentDataStore(ppss.lake_ss.lake_dir)
-    PDS._create_and_fill_table(
-        _gql_datafactory_first_predictions_df, predictions_table_name
-    )
-
-    records = table.get_records()
-
-    assert len(records) == len(_gql_datafactory_first_predictions_df)
-    assert records["ID"][0] == _gql_datafactory_first_predictions_df["ID"][0]
-    assert records["pair"][0] == _gql_datafactory_first_predictions_df["pair"][0]
-    assert (
-        records["timeframe"][0] == _gql_datafactory_first_predictions_df["timeframe"][0]
-    )


### PR DESCRIPTION
Fixes #809 

Changes proposed in this PR:

- The `get_records` method of the `Table` class has been removed.
- The `PredFilter` class has been removed and replaced with SQL queries in places where the class was used.
- The tests have been fixed.
- The test methods that query the entire table have not been changed as it was deemed unnecessary.