### PR TITLE
Fix asyncio version by downgrading to 21.1 again for CI warnings.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ install_requirements = [
     "pyarrow==15.0.2",
     "pylint==3.1.0",
     "pytest",
-    "pytest-asyncio==0.23.6",
+    # pytest-asyncio: do not use dependabot to upgrade without checking lib changelog
+    "pytest-asyncio==0.21.1",
     "pytest-env",
     "pyyaml",
     "requests==2.31.0",


### PR DESCRIPTION
Echoes #531. Apparently pytest-asyncio did not fix their issue with subsequent versions. Downgrading back to 21.1 and adding instructions in setup.py to be mindful of the changelog before approving dependabot upgrades.