### PR TITLE
Fix #859 - ETL + DuckDB encountered issues

### DIFF
--- a/pdr_backend/lake/csv_data_store.py
+++ b/pdr_backend/lake/csv_data_store.py
@@ -8,7 +8,6 @@ from pdr_backend.lake.base_data_store import BaseDataStore
 
 
 class CSVDataStore(BaseDataStore):
-
     @enforce_types
     def _get_folder_path(self, dataset_identifier: str) -> str:
         """

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.lake.gql_data_factory import GQLDataFactory

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -211,7 +211,7 @@ class ETL:
 
         return values
 
-    def _calc_bronze_start_end_ts(self, tabletype: TableType = TableType.TEMP):
+    def _calc_bronze_start_end_ts(self):
         """
         @description
             Calculate the start and end timestamps for the bronze tables
@@ -234,17 +234,7 @@ class ETL:
             self.raw_table_names, TableType.TEMP
         ).values()
 
-        fin_timestamp = (
-            self.ppss.lake_ss.fin_timestr
-            if self.ppss.lake_ss.fin_timestr != "now"
-            else datetime.now().strftime("%Y-%m-%d_%H:%M")
-        )
-
-        to_timestamp = (
-            min(to_values)
-            if None not in to_values
-            else datetime.strptime(fin_timestamp, "%Y-%m-%d_%H:%M")
-        )
+        to_timestamp = min(to_values)
 
         return from_timestamp, to_timestamp
 

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -200,19 +200,17 @@ class ETL:
 
         return values
 
-    def get_timestamp_values(self, table_names: str, default_timestr: str) -> UnixTimeMs:
+    def get_timestamp_values(
+        self, table_names: List[str], default_timestr: str
+    ) -> UnixTimeMs:
         max_timestamp_values = self._get_max_timestamp_values_from(
             [NamedTable(tb, TableType.NORMAL) for tb in table_names]
         )
         values = []
         if len(max_timestamp_values) > 0:
-            values = [
-                value[1] for value in max_timestamp_values if value is not None
-            ]
+            values = [value[1] for value in max_timestamp_values if value is not None]
         timestamp = (
-            min(values)
-            if len(values) > 0
-            else UnixTimeMs.from_timestr(default_timestr)
+            min(values) if len(values) > 0 else UnixTimeMs.from_timestr(default_timestr)
         )
         return timestamp
 

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -164,7 +164,9 @@ class ETL:
             "SELECT '{}' as table_name, MAX(timestamp) as max_timestamp FROM {}"
         )
 
-        all_db_tables = PersistentDataStore(self.ppss.lake_ss.lake_dir).get_table_names()
+        all_db_tables = PersistentDataStore(
+            self.ppss.lake_ss.lake_dir
+        ).get_table_names()
 
         queries = []
 
@@ -177,9 +179,7 @@ class ETL:
                 continue
 
             queries.append(
-                max_timestamp_query.format(
-                    table_name_with_type, table_name_with_type
-                )
+                max_timestamp_query.format(table_name_with_type, table_name_with_type)
             )
 
         none_values: Dict[str, Optional[datetime]] = {
@@ -234,9 +234,11 @@ class ETL:
             self.raw_table_names, TableType.TEMP
         ).values()
 
-        fin_timestamp = self.ppss.lake_ss.fin_timestr if self.ppss.lake_ss.fin_timestr != "now" else datetime.now().strftime(
-                "%Y-%m-%d_%H:%M"
-            )
+        fin_timestamp = (
+            self.ppss.lake_ss.fin_timestr
+            if self.ppss.lake_ss.fin_timestr != "now"
+            else datetime.now().strftime("%Y-%m-%d_%H:%M")
+        )
 
         to_timestamp = (
             min(to_values)

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -38,7 +38,6 @@ from pdr_backend.lake.table_pdr_predictions import _transform_timestamp_to_ms
 from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.csv_data_store import CSVDataStore
-from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 logger = logging.getLogger("gql_data_factory")
 

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Dict
 from enforce_typing import enforce_types
 import polars as pl
-from pdr_backend.lake.table import Table, TableType, get_table_name
+from pdr_backend.lake.table import Table, TableType, get_table_name, TempTable
 from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.subgraph.subgraph_predictions import get_all_contract_ids_by_owner
 from pdr_backend.util.networkutil import get_sapphire_postfix
@@ -267,7 +267,7 @@ class GQLDataFactory:
         pds = PersistentDataStore(self.ppss.lake_ss.lake_dir)
         for table_name in self.record_config["gql_tables"]:
             pds.move_table_data(
-                get_table_name(table_name, TableType.TEMP),
+                TempTable(table_name),
                 table_name,
             )
 

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -293,7 +293,6 @@ class GQLDataFactory:
         for _, table in (
             TableRegistry().get_tables(self.record_config["gql_tables"]).items()
         ):
-
             # calculate start and end timestamps
             st_ut = self._calc_start_ut(table)
             fin_ut = self.ppss.lake_ss.fin_timestamp

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -37,7 +37,7 @@ from pdr_backend.lake.plutil import _object_list_to_df, get_table_name, TableTyp
 from pdr_backend.lake.table_pdr_predictions import _transform_timestamp_to_ms
 from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.lake.csv_data_store import CSVDataStore
-
+from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 logger = logging.getLogger("gql_data_factory")
 
@@ -155,6 +155,10 @@ class GQLDataFactory:
         pagination_offset = 0
 
         buffer_df = pl.DataFrame([], schema=table.df_schema)
+
+        PersistentDataStore(self.ppss.lake_ss.lake_dir).create_table_if_not_exists(
+            get_table_name(table.table_name, TableType.TEMP), table.df_schema
+        )
 
         while True:
             # call the function

--- a/pdr_backend/lake/persistent_data_store.py
+++ b/pdr_backend/lake/persistent_data_store.py
@@ -8,6 +8,7 @@ from polars.type_aliases import SchemaDict
 from enforce_typing import enforce_types
 import polars as pl
 
+
 from pdr_backend.lake.base_data_store import BaseDataStore
 
 
@@ -174,11 +175,11 @@ class PersistentDataStore(BaseDataStore):
         self.duckdb_conn.execute(f"DROP VIEW IF EXISTS {view_name}")
 
     @enforce_types
-    def move_table_data(self, temp_table_name: str, permanent_table_name: str):
+    def move_table_data(self, temp_table, permanent_table_name: str):
         """
         Move the table data from the temporary storage to the permanent storage.
         @arguments:
-            temp_table_name - The name of the temporary table.
+            temp_table - The temporary table object
             permanent_table_name - The name of the permanent table.
         @example:
             move_table_data("temp_people", "people")
@@ -187,20 +188,22 @@ class PersistentDataStore(BaseDataStore):
         # Check if the table exists
         table_names = self.get_table_names()
 
-        if temp_table_name in table_names:
-            # check if the permanent table exists
-            if permanent_table_name not in table_names:
-                # create table if it does not exist
-                self.duckdb_conn.execute(
-                    f"CREATE TABLE {permanent_table_name} AS SELECT * FROM {temp_table_name}"
-                )
-            else:
-                # Move the data from the temporary table to the permanent table
-                self.duckdb_conn.execute(
-                    f"INSERT INTO {permanent_table_name} SELECT * FROM {temp_table_name}"
-                )
-        else:
-            raise Exception(f"Table {temp_table_name} does not exist")
+        if temp_table.fullname not in table_names:
+            raise Exception(f"Table {temp_table.fullname} does not exist")
+
+        # check if the permanent table exists
+        if permanent_table_name not in table_names:
+            # create table if it does not exist
+            self.duckdb_conn.execute(
+                f"CREATE TABLE {permanent_table_name} AS SELECT * FROM {temp_table.fullname}"
+            )
+
+            return
+
+        # Move the data from the temporary table to the permanent table
+        self.duckdb_conn.execute(
+            f"INSERT INTO {permanent_table_name} SELECT * FROM {temp_table.fullname}"
+        )
 
     @enforce_types
     def fill_from_csv_destination(self, csv_folder_path: str, table_name: str):
@@ -241,7 +244,7 @@ class PersistentDataStore(BaseDataStore):
             [f"{column} = {df[column]}" for column in df.columns]
         )
         self.duckdb_conn.execute(
-            f"""UPDATE {table_name} 
-            SET {update_columns} 
+            f"""UPDATE {table_name}
+            SET {update_columns}
             WHERE {column_name} = {df[column_name]}"""
         )

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -73,3 +73,19 @@ class Table:
         table_name = get_table_name(self.table_name, table_type)
         PersistentDataStore(self.base_path).insert_to_table(data, table_name)
         print(f"  Appended {data.shape[0]} rows to db table: {table_name}")
+
+
+@enforce_types
+class NamedTable:
+    def __init__(self, table_name: str, table_type: TableType = TableType.NORMAL):
+        self.table_name = table_name
+        self.table_type = table_type
+
+    @property
+    def fullname(self) -> str:
+        return get_table_name(self.table_name, self.table_type)
+
+
+class TempTable(NamedTable):
+    def __init__(self, table_name: str):
+        super().__init__(table_name, TableType.TEMP)

--- a/pdr_backend/lake/table_bronze_pdr_slots.py
+++ b/pdr_backend/lake/table_bronze_pdr_slots.py
@@ -34,7 +34,6 @@ bronze_pdr_slots_schema = {
 def get_bronze_pdr_slots_data_with_SQL(
     path: str, st_ms: UnixTimeMs, fin_ms: UnixTimeMs
 ) -> pl.DataFrame:
-
     pdr_slots_table_name = get_table_name(slots_table_name)
     pdr_truevals_table_name = get_table_name(truevals_table_name)
     pdr_payouts_table_name = get_table_name(payouts_table_name)

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -410,6 +410,7 @@ def _mock_fetch_gql():
 
     return fetch_function
 
+
 @pytest.fixture()
 def _mock_fetch_empty_gql():
     # return a callable that returns a list of objects
@@ -422,6 +423,7 @@ def _mock_fetch_empty_gql():
         return mock_first_predictions(0)
 
     return fetch_function
+
 
 @pytest.fixture()
 def _gql_datafactory_first_predictions_df():

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -410,6 +410,18 @@ def _mock_fetch_gql():
 
     return fetch_function
 
+@pytest.fixture()
+def _mock_fetch_empty_gql():
+    # return a callable that returns a list of objects
+    def fetch_function(
+        network, st_ut, fin_ut, save_backoff_limit, pagination_limit, config
+    ):
+        print(
+            f"{network}, {st_ut}, {fin_ut}, {save_backoff_limit}, {pagination_limit}, {config}"
+        )
+        return mock_first_predictions(0)
+
+    return fetch_function
 
 @pytest.fixture()
 def _gql_datafactory_first_predictions_df():

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -25,7 +25,6 @@ from pdr_backend.lake.table_bronze_pdr_predictions import (
     bronze_pdr_predictions_table_name,
 )
 from pdr_backend.lake.table_bronze_pdr_slots import bronze_pdr_slots_table_name
-from datetime import datetime
 
 
 @enforce_types

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -271,7 +271,9 @@ def test_get_max_timestamp_values_from(tmpdir):
         INSERT INTO test_table_2 VALUES (INT64 '{1}');
         INSERT INTO test_table_2 VALUES (INT64 '{2}');
         INSERT INTO test_table_3 VALUES (INT64 '{3}');
-        """.format(ts1, ts2, ts3, ts4)
+        """.format(
+            ts1, ts2, ts3, ts4
+        )
     )
 
     st_timestr = "2023-11-02_0:00"
@@ -290,19 +292,16 @@ def test_get_max_timestamp_values_from(tmpdir):
         ["test_table_1", "test_table_2", "test_table_3"]
     )
     assert (
-        UnixTimeMs(max_timestamp_values[0][1]).to_dt().strftime(
-            "%Y-%m-%d %H:%M:%S"
-        ) == "2023-11-02 00:00:00"
+        UnixTimeMs(max_timestamp_values[0][1]).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-02 00:00:00"
     )
     assert (
-        UnixTimeMs(max_timestamp_values[1][1]).to_dt().strftime(
-                "%Y-%m-%d %H:%M:%S"
-        )== "2023-11-04 00:00:00"
+        UnixTimeMs(max_timestamp_values[1][1]).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-04 00:00:00"
     )
     assert (
-        UnixTimeMs(max_timestamp_values[2][1]).to_dt().strftime(
-                "%Y-%m-%d %H:%M:%S"
-        )== "2023-11-09 00:00:00"
+        UnixTimeMs(max_timestamp_values[2][1]).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-09 00:00:00"
     )
 
 
@@ -338,7 +337,9 @@ def _fill_dummy_tables(tmpdir):
         INSERT INTO bronze_table_2 VALUES (INT64 '{0}');
         INSERT INTO bronze_table_2 VALUES (INT64 '{1}');
         INSERT INTO bronze_table_3 VALUES (INT64 '{1}');
-        """.format(ts1, ts2)
+        """.format(
+            ts1, ts2
+        )
     )
 
     # raw tables can have different max timestamps
@@ -353,7 +354,9 @@ def _fill_dummy_tables(tmpdir):
         INSERT INTO raw_table_2 VALUES (INT64 '{1}');
         INSERT INTO raw_table_2 VALUES (INT64 '{2}');
         INSERT INTO raw_table_3 VALUES (INT64 '{3}');
-        """.format(ts1, ts2, ts3, ts4)
+        """.format(
+            ts1, ts2, ts3, ts4
+        )
     )
 
 
@@ -390,9 +393,15 @@ def test_calc_bronze_start_end_ts(tmpdir):
 
     # Calculate from + to timestamps
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
-    
-    assert UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
-    assert UnixTimeMs(to_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-21 00:00:00"
+
+    assert (
+        UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-02 00:00:00"
+    )
+    assert (
+        UnixTimeMs(to_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-21 00:00:00"
+    )
 
 
 @enforce_types
@@ -426,8 +435,14 @@ def test_calc_bronze_start_end_ts_with_nonexist_tables(tmpdir):
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
-    assert UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
-    assert UnixTimeMs(to_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-07 00:00:00"
+    assert (
+        UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-02 00:00:00"
+    )
+    assert (
+        UnixTimeMs(to_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-07 00:00:00"
+    )
 
 
 @enforce_types
@@ -454,8 +469,12 @@ def test_calc_bronze_start_end_ts_with_now_value(tmpdir):
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
     ts_now = UnixTimeMs.now()
-    assert UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
+    assert (
+        UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-02 00:00:00"
+    )
     assert abs(ts_now - to_timestamp) < 100
+
 
 @enforce_types
 def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
@@ -489,5 +508,8 @@ def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
     ts_now = UnixTimeMs.now()
-    assert UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
+    assert (
+        UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")
+        == "2023-11-02 00:00:00"
+    )
     assert abs(ts_now - to_timestamp) < 100

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -27,6 +27,7 @@ from pdr_backend.lake.table_bronze_pdr_predictions import (
 from pdr_backend.lake.table_bronze_pdr_slots import bronze_pdr_slots_table_name
 from datetime import datetime
 
+
 @enforce_types
 def get_filtered_timestamps_df(
     df: pl.DataFrame, st_timestr: str, fin_timestr: str
@@ -447,6 +448,7 @@ def test_get_max_timestamp_values_from(tmpdir):
         == "2023-11-04 00:00:00"
     )
 
+
 def _fill_dummy_tables(tmpdir):
     pds = PersistentDataStore(str(tmpdir))
 
@@ -484,6 +486,7 @@ def _fill_dummy_tables(tmpdir):
         """
     )
 
+
 @enforce_types
 def test_calc_bronze_start_end_ts(tmpdir):
     _clean_up_persistent_data_store(tmpdir)
@@ -511,6 +514,7 @@ def test_calc_bronze_start_end_ts(tmpdir):
     assert to_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-21 00:00:00"
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
 
+
 @enforce_types
 def test_calc_bronze_start_end_ts_with_nonexist_tables(tmpdir):
     _clean_up_persistent_data_store(tmpdir)
@@ -533,14 +537,13 @@ def test_calc_bronze_start_end_ts_with_nonexist_tables(tmpdir):
         "test_bronze_table_3",
         "test_bronze_table_4",
         "test_bronze_table_5",
-
     ]
     etl.raw_table_names = [
         "dummy_table_1",
         "dummy_table_2",
         "dummy_table_3",
         "dummy_table_4",
-        "dummy_table_5"
+        "dummy_table_5",
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
@@ -575,6 +578,7 @@ def test_calc_bronze_start_end_ts_with_now_value(tmpdir):
     assert to_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-21 00:00:00"
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
 
+
 @enforce_types
 def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
     _clean_up_persistent_data_store(tmpdir)
@@ -603,9 +607,11 @@ def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
         "dummy_table_2",
         "dummy_table_3",
         "dummy_table_4",
-        "dummy_table_5"
+        "dummy_table_5",
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
-    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == datetime.now().strftime("%Y-%m-%d %H:%M")
+    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == datetime.now().strftime(
+        "%Y-%m-%d %H:%M"
+    )
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -611,5 +611,5 @@ def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
-    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == '2023-11-21 00:00'
+    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == "2023-11-21 00:00"
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -289,18 +289,20 @@ def test_get_max_timestamp_values_from(tmpdir):
     max_timestamp_values = etl._get_max_timestamp_values_from(
         ["test_table_1", "test_table_2", "test_table_3"]
     )
-
     assert (
-        max_timestamp_values["test_table_1"].strftime("%Y-%m-%d %H:%M:%S")
-        == "2023-11-02 00:00:00"
+        UnixTimeMs(max_timestamp_values[0][1]).to_dt().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ) == "2023-11-02 00:00:00"
     )
     assert (
-        max_timestamp_values["test_table_2"].strftime("%Y-%m-%d %H:%M:%S")
-        == "2023-11-09 00:00:00"
+        UnixTimeMs(max_timestamp_values[1][1]).to_dt().strftime(
+                "%Y-%m-%d %H:%M:%S"
+        )== "2023-11-04 00:00:00"
     )
     assert (
-        max_timestamp_values["test_table_3"].strftime("%Y-%m-%d %H:%M:%S")
-        == "2023-11-04 00:00:00"
+        UnixTimeMs(max_timestamp_values[2][1]).to_dt().strftime(
+                "%Y-%m-%d %H:%M:%S"
+        )== "2023-11-09 00:00:00"
     )
 
 

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -547,7 +547,7 @@ def test_calc_bronze_start_end_ts_with_nonexist_tables(tmpdir):
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
-    assert to_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-07 00:00:00"
+    assert to_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-21 00:00:00"
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"
 
 
@@ -611,7 +611,5 @@ def test_calc_bronze_start_end_ts_with_now_value_and_nonexist_tables(tmpdir):
     ]
     from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
-    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == datetime.now().strftime(
-        "%Y-%m-%d %H:%M"
-    )
+    assert to_timestamp.strftime("%Y-%m-%d %H:%M") == '2023-11-21 00:00'
     assert from_timestamp.strftime("%Y-%m-%d %H:%M:%S") == "2023-11-02 00:00:00"

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -5,7 +5,7 @@ from enforce_typing import enforce_types
 import polars as pl
 from pdr_backend.lake.test.resources import _gql_data_factory
 from pdr_backend.lake.etl import ETL
-from pdr_backend.lake.table import TableType, get_table_name
+from pdr_backend.lake.table import TableType, get_table_name, NamedTable
 from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
 from pdr_backend.lake.table_registry import TableRegistry
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
@@ -289,7 +289,11 @@ def test_get_max_timestamp_values_from(tmpdir):
     etl = ETL(ppss, gql_data_factory)
 
     max_timestamp_values = etl._get_max_timestamp_values_from(
-        ["test_table_1", "test_table_2", "test_table_3"]
+        [
+            NamedTable("test_table_1"),
+            NamedTable("test_table_2"),
+            NamedTable("test_table_3"),
+        ]
     )
     assert (
         UnixTimeMs(max_timestamp_values[0][1]).to_dt().strftime("%Y-%m-%d %H:%M:%S")

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -238,3 +238,50 @@ def test_do_subgraph_fetch(
     printed_text = captured_output.getvalue().strip()
     count_fetches = printed_text.count("Fetched")
     assert count_fetches == 1
+
+def test_do_fetch_with_empty_data(
+    _mock_fetch_empty_gql,
+    _clean_up_test_folder,
+    tmpdir,
+):
+    _clean_up_table_registry()
+
+    st_timestr = "2023-12-03"
+    fin_timestr = "2023-12-05"
+    ppss = mock_ppss(
+        ["binance BTC/USDT c 5m"],
+        "sapphire-mainnet",
+        str(tmpdir),
+        st_timestr=st_timestr,
+        fin_timestr=fin_timestr,
+    )
+
+    _clean_up_test_folder(ppss.lake_ss.lake_dir)
+
+    gql_data_factory = GQLDataFactory(ppss)
+
+    table = TableRegistry().get_table("pdr_predictions")
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+    gql_data_factory._do_subgraph_fetch(
+        table,
+        _mock_fetch_empty_gql,
+        "sapphire-mainnet",
+        UnixTimeMs(1701634300000),
+        UnixTimeMs(1701634500000),
+        {"contract_list": ["0x123"]},
+    )
+    printed_text = captured_output.getvalue().strip()
+    count_fetches = printed_text.count("Fetched")
+    assert count_fetches == 1
+
+    #check if the db table is created
+
+    temp_table_name = get_table_name("pdr_predictions", TableType.TEMP)
+    all_tables = PersistentDataStore(ppss.lake_ss.lake_dir).get_table_names()
+
+    assert temp_table_name in all_tables
+    assert len(PersistentDataStore(ppss.lake_ss.lake_dir).query_data(
+        "SELECT * FROM {}".format(temp_table_name)
+    )) == 0

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -277,11 +277,4 @@ def test_do_fetch_with_empty_data(
     all_tables = pds.get_table_names()
 
     assert temp_table_name in all_tables
-    assert (
-        len(
-            pds.query_data(
-                "SELECT * FROM {}".format(temp_table_name)
-            )
-        )
-        == 0
-    )
+    assert len(pds.query_data("SELECT * FROM {}".format(temp_table_name))) == 0

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -3,6 +3,7 @@ from io import StringIO
 import sys
 from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.lake.gql_data_factory import GQLDataFactory
+from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.util.time_types import UnixTimeMs
 from pdr_backend.lake.table import TableType, get_table_name
 from pdr_backend.lake.table_registry import TableRegistry
@@ -272,12 +273,13 @@ def test_do_fetch_with_empty_data(
     # check if the db table is created
 
     temp_table_name = get_table_name("pdr_predictions", TableType.TEMP)
-    all_tables = PersistentDataStore(ppss.lake_ss.lake_dir).get_table_names()
+    pds = PersistentDataStore(ppss.lake_ss.lake_dir)
+    all_tables = pds.get_table_names()
 
     assert temp_table_name in all_tables
     assert (
         len(
-            PersistentDataStore(ppss.lake_ss.lake_dir).query_data(
+            pds.query_data(
                 "SELECT * FROM {}".format(temp_table_name)
             )
         )

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -239,6 +239,7 @@ def test_do_subgraph_fetch(
     count_fetches = printed_text.count("Fetched")
     assert count_fetches == 1
 
+
 def test_do_fetch_with_empty_data(
     _mock_fetch_empty_gql,
     _clean_up_test_folder,
@@ -276,12 +277,17 @@ def test_do_fetch_with_empty_data(
     count_fetches = printed_text.count("Fetched")
     assert count_fetches == 1
 
-    #check if the db table is created
+    # check if the db table is created
 
     temp_table_name = get_table_name("pdr_predictions", TableType.TEMP)
     all_tables = PersistentDataStore(ppss.lake_ss.lake_dir).get_table_names()
 
     assert temp_table_name in all_tables
-    assert len(PersistentDataStore(ppss.lake_ss.lake_dir).query_data(
-        "SELECT * FROM {}".format(temp_table_name)
-    )) == 0
+    assert (
+        len(
+            PersistentDataStore(ppss.lake_ss.lake_dir).query_data(
+                "SELECT * FROM {}".format(temp_table_name)
+            )
+        )
+        == 0
+    )

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -2,7 +2,7 @@ import os
 import polars as pl
 import duckdb
 
-from pdr_backend.lake.table import TableType, get_table_name
+from pdr_backend.lake.table import TableType, get_table_name, TempTable
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.test.conftest import _clean_up_persistent_data_store
 from pdr_backend.lake.csv_data_store import CSVDataStore
@@ -239,9 +239,7 @@ def test_move_table_data(tmpdir):
     assert table_exists
 
     # Move the table
-    persistent_data_store.move_table_data(
-        get_table_name(table_name, TableType.TEMP), table_name
-    )
+    persistent_data_store.move_table_data(TempTable(table_name), table_name)
 
     # Assert table hasn't dropped
     table_names = persistent_data_store.get_table_names()
@@ -281,7 +279,7 @@ def test_etl_view(tmpdir):
     view_name = get_table_name(table_name, TableType.ETL)
     view_query = """
     CREATE VIEW {} AS
-    ( 
+    (
         SELECT * FROM {}
         UNION ALL
         SELECT * FROM {}

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -323,6 +323,7 @@ def test_etl_view(tmpdir):
     ).fetchall()
     assert result[0][0] == "2022-06-01"
 
+
 def test_create_table_if_not_exists(tmpdir):
     """
     Test create table if not exists.

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -322,3 +322,21 @@ def test_etl_view(tmpdir):
         f"SELECT max(timestamp) FROM {view_name}"
     ).fetchall()
     assert result[0][0] == "2022-06-01"
+
+def test_create_table_if_not_exists(tmpdir):
+    """
+    Test create table if not exists.
+    """
+    _clean_up_persistent_data_store(tmpdir)
+
+    persistent_data_store, example_df, table_name = _get_persistent_data_store(tmpdir)
+
+    example_df_schema = example_df.schema
+    # Create table
+    persistent_data_store.create_table_if_not_exists(table_name, example_df_schema)
+
+    # Check if the table is registered
+    check_result, table_name = _table_exists(persistent_data_store, table_name)
+    assert check_result
+
+    _clean_up_persistent_data_store(tmpdir)

--- a/system_tests/test_get_predictoors_info_system.py
+++ b/system_tests/test_get_predictoors_info_system.py
@@ -18,7 +18,6 @@ from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 @patch("pdr_backend.analytics.get_predictions_info.get_predictoor_summary_stats")
 def test_get_predictoors_info_system(get_get_predictoor_summary_stats, caplog):
-
     mock_web3_pp = MagicMock(spec=Web3PP)
     mock_web3_pp.network = "sapphire-mainnet"
     mock_web3_pp.subgraph_url = (

--- a/system_tests/test_get_traction_info_system.py
+++ b/system_tests/test_get_traction_info_system.py
@@ -17,7 +17,6 @@ from pdr_backend.lake.persistent_data_store import PersistentDataStore
 
 @patch("pdr_backend.analytics.get_predictions_info.plot_slot_daily_statistics")
 def test_traction_info_system(mock_plot_stats, caplog):
-
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
     user_addr = "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd"
     mock_predictions = [


### PR DESCRIPTION
Fixes #859 

Changes proposed in this PR:

- the empty table issue is fixed
- the "now" value issue on the etl is fixed


[idiom-bytes updates]
- [x] merged my larger PR into this PR
- [x] resolved conflicts, iterated on the logic, and (2) cleaned up a bunch of code.
- [x] i noticed that there were (2) a bunch of [variables, function args, return values] called timestamp but weren't... they were datetime str, timestr, and other values.
- [x] added a bunch of type-checks, asserts, and updated this everywhere so that if something is called a timestamp, I can expect it to be a UnixTimeS or UnixTimeMs
- [x] updated tests so dummy_tables use INT64 (actual unix timestamp) rather than a TIMESTAMP (which is a datetime) and was causing conflicts with the code, introducing a mixture-of-concerns that should not be there