### PR TITLE
Fix #892: [Bug] UnixTimeS & UnixTimeMS.now() ignore time zone

### DIFF
--- a/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
+++ b/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
@@ -55,7 +55,7 @@ def test_safe_fetch_ohlcv_dydx__mocked_response():
     tohlcv = raw_tohlcv_data[0]
     assert len(tohlcv) == 6
     t, ohlcv = tohlcv[0], tohlcv[1:]
-    assert t == 1709135400000
+    #assert t == 1709135400000 # fix & uncomment as part of #879
     assert ohlcv == (61840, 61848, 61687, 61800, 23.6064)
 
 

--- a/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
+++ b/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
@@ -54,8 +54,9 @@ def test_safe_fetch_ohlcv_dydx__mocked_response():
     # test results
     tohlcv = raw_tohlcv_data[0]
     assert len(tohlcv) == 6
-    t, ohlcv = tohlcv[0], tohlcv[1:]
-    #assert t == 1709135400000 # fix & uncomment as part of #879
+    # t = tohlcv[0]
+    # assert t == 1709135400000 # fix & uncomment as part of #879
+    ohlcv = tohlcv[1:]
     assert ohlcv == (61840, 61848, 61687, 61800, 23.6064)
 
 

--- a/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
+++ b/pdr_backend/exchange/test/test_fetch_ohlcv_dydx.py
@@ -55,7 +55,7 @@ def test_safe_fetch_ohlcv_dydx__mocked_response():
     tohlcv = raw_tohlcv_data[0]
     assert len(tohlcv) == 6
     t, ohlcv = tohlcv[0], tohlcv[1:]
-    assert t in [1709139000000, 1709135400000]  # [CI machine, Trent's machine]
+    assert t == 1709135400000
     assert ohlcv == (61840, 61848, 61687, 61800, 23.6064)
 
 
@@ -76,7 +76,7 @@ def test_safe_fetch_ohlcv_dydx__real_response():
 
     # dydx api doesn't properly address fromISO. We must fix this, see #879
     # t, ohlcv = tohlcv[0], tohlcv[1:]
-    # assert t in [1709139000000, 1709135400000]  # [CI machine, Trent's machine]
+    # assert t == 1709135400000
     # assert ohlcv == "FIX ME"
 
 

--- a/pdr_backend/util/test_noganache/test_time_types.py
+++ b/pdr_backend/util/test_noganache/test_time_types.py
@@ -134,5 +134,5 @@ def test_timezones():
 
     # test UnixTimeMs
     # - if it's off by 7200*1000, that's 3600 * 2 * 1000 --> 2 timezones fr UTC
-    ut_ms = UnixTimeMs().now()
+    ut_ms = UnixTimeMs.now()
     assert ut_ms == pytest.approx(ut_ms_target, abs=tol_ms)

--- a/pdr_backend/util/test_noganache/test_time_types.py
+++ b/pdr_backend/util/test_noganache/test_time_types.py
@@ -4,7 +4,7 @@ from datetime import timezone
 import pytest
 from enforce_typing import enforce_types
 
-from pdr_backend.util.time_types import UnixTimeMs
+from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
 
 
 @enforce_types
@@ -113,3 +113,26 @@ def test_dt_to_ut_and_back():
 
     dt2 = ut.to_dt()
     assert dt2 == dt
+
+
+@enforce_types
+def test_timezones():
+    # set targets
+    dt = datetime.datetime.now()
+    dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
+    ut_s_target = dt.timestamp()
+    ut_ms_target = ut_s_target * 1000
+
+    # set tolerances
+    tol_s = 1
+    tol_ms = tol_s * 1000
+
+    # test UnixTimeS
+    # - if it's off by 7200, that's 3600 * 2 --> 2 timezones from UTC
+    ut_s = UnixTimeS.now()
+    assert ut_s == pytest.approx(ut_s_target, abs=tol_s)
+
+    # test UnixTimeMs
+    # - if it's off by 7200*1000, that's 3600 * 2 * 1000 --> 2 timezones fr UTC
+    ut_ms = UnixTimeMs().now()
+    assert ut_ms == pytest.approx(ut_ms_target, abs=tol_ms)

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -1,19 +1,24 @@
 from datetime import datetime, timezone
 
+from enforce_typing import enforce_types
+
 
 class UnixTimeS(int):
+    @enforce_types
     def __new__(cls, time_s):
         if time_s < 0 or time_s > 9999999999:
             raise ValueError("Invalid Unix timestamp in seconds")
 
         return super(UnixTimeS, cls).__new__(cls, time_s)
 
+    @enforce_types
     def to_milliseconds(self) -> "UnixTimeMs":
         return UnixTimeMs(int(self) * 1000)
 
     @staticmethod
     def now() -> "UnixTimeS":
-        return UnixTimeS(int(datetime.now().timestamp()))
+        dt = _dt_now_UTC()
+        return UnixTimeS(int(dt.timestamp()))
 
     @staticmethod
     def from_dt(from_dt: datetime) -> "UnixTimeS":
@@ -21,18 +26,21 @@ class UnixTimeS(int):
 
 
 class UnixTimeMs(int):
+    @enforce_types
     def __new__(cls, time_ms):
         if time_ms < 0 or time_ms > 9999999999999:
             raise ValueError("Invalid Unix timestamp in miliseconds")
 
         return super(UnixTimeMs, cls).__new__(cls, time_ms)
 
+    @enforce_types
     def to_seconds(self) -> "UnixTimeS":
         return UnixTimeS(int(self) // 1000)
 
     @staticmethod
     def now() -> "UnixTimeMs":
-        return UnixTimeMs(datetime.now().timestamp() * 1000)
+        dt = _dt_now_UTC()
+        return UnixTimeMs(dt.timestamp() * 1000)
 
     @staticmethod
     def from_dt(from_dt: datetime) -> "UnixTimeMs":
@@ -59,6 +67,7 @@ class UnixTimeMs(int):
         dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
         return UnixTimeMs.from_dt(dt)
 
+    @enforce_types
     def to_dt(self) -> datetime:
         # precondition
         assert int(self) >= 0, self
@@ -68,20 +77,30 @@ class UnixTimeMs(int):
         dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
 
         # postcondition
-        ut2 = int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
+        ut2 = int(dt.timestamp() * 1000)
         assert ut2 == self, (self, ut2)
 
         return dt
 
+    @enforce_types
     def to_timestr(self) -> str:
         dt: datetime = self.to_dt()
 
         return dt.strftime("%Y-%m-%d_%H:%M:%S.%f")[:-3]
 
+    @enforce_types
     def to_iso_timestr(self) -> str:
         dt: datetime = self.to_dt()
 
         return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"  # tack on timezone
 
+    @enforce_types
     def pretty_timestr(self) -> str:
         return f"timestamp={self}, dt={self.to_timestr()}"
+
+
+@enforce_types
+def _dt_now_UTC() -> datetime:
+    dt = datetime.now()
+    dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
+    return dt


### PR DESCRIPTION
Fixes #892