### PR TITLE
Fix #901: [Warning] datetime.utcfromtimestamp() is deprecated

### DIFF
--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 from enforce_typing import enforce_types
 
@@ -80,7 +80,7 @@ class UnixTimeMs(int):
         assert int(self) >= 0, self
 
         # main work
-        dt = datetime.utcfromtimestamp(int(self) / 1000)
+        dt = datetime.fromtimestamp(int(self) / 1000, UTC)
         dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
 
         # postcondition


### PR DESCRIPTION
…, scheduled for removal

Fixes #901
