### PR TITLE
Fix #909 - Vanilla pdr sync failing

### DIFF
--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -131,8 +131,12 @@ class ETL:
 
             end_ts = time.time_ns() / 1e9
             logger.info("do_etl - Completed bronze_step in %s sec.", end_ts - st_ts)
-
+            
+            # At the end of the ETL pipeline, we want to
+            # 1. move from TEMP tables to production tables
+            # 2. drop TEMP tables and ETL views
             self._move_from_temp_tables_to_live()
+
             logger.info(
                 "do_etl - Moved build tables to permanent tables. ETL Complete."
             )
@@ -286,16 +290,17 @@ class ETL:
                     SELECT * FROM {}
                 )""".format(
                 etl_view_name,
-                get_table_name(table_name),
+                table_name,
                 temp_table_name,
             )
+            pds.query_data(view_query)
+            logger.info("  Created %s view using %s table and %s temp table", etl_view_name, table_name, temp_table_name)
         else:
             view_query = (
                 f"CREATE VIEW {etl_view_name} AS SELECT * FROM {temp_table_name}"
             )
-
-        pds.query_data(view_query)
-        logger.info("  Created %s view", table_name)
+            pds.query_data(view_query)
+            logger.info("  Created %s view using %s temp table", etl_view_name, temp_table_name)
 
     def update_bronze_pdr(self):
         """
@@ -323,8 +328,3 @@ class ETL:
             # For each bronze table that we process, that data will be entered into TEMP
             # Create view so downstream queries can access production + TEMP data
             self.create_etl_view(table_name)
-
-        # At the end of the ETL pipeline, we want to
-        # 1. move from TEMP tables to production tables
-        # 2. drop TEMP tables and ETL views
-        self._move_from_temp_tables_to_live()

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -60,6 +60,7 @@ def test_etl_do_bronze_step(
 
     # Work 1: Do bronze
     etl.do_bronze_step()
+    etl._move_from_temp_tables_to_live()
 
     # assert bronze_pdr_predictions_df is created
     table_name = get_table_name(bronze_pdr_predictions_table_name)
@@ -163,6 +164,7 @@ def test_etl_views(setup_data):
     # Work 1: First Run
     with patch("pdr_backend.lake.etl.ETL._move_from_temp_tables_to_live") as mock:
         etl.do_bronze_step()
+        etl._move_from_temp_tables_to_live()
         assert mock.called
 
     # live table shouldn't exist


### PR DESCRIPTION
Fixes #909 

Changes proposed in this PR:Issue
- Only call `_move_from_temp_tables_to_live()` once
- Improve logging so we can understand what it's going on
- Update tests and logic to support this