### PR TITLE
Fix #1003: Process dates with natural language processing.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,6 +14,9 @@ ignore_missing_imports = True
 [mypy-dash.*]
 ignore_missing_imports = True
 
+[mypy-dateparser.*]
+ignore_missing_imports = True
+
 [mypy-ecies.*]
 ignore_missing_imports = True
 

--- a/pdr_backend/ppss/test/test_lake_ss.py
+++ b/pdr_backend/ppss/test/test_lake_ss.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from datetime import timedelta
 
 import pytest
 from enforce_typing import enforce_types
@@ -7,7 +8,7 @@ from enforce_typing import enforce_types
 from pdr_backend.cli.arg_feed import ArgFeed
 from pdr_backend.cli.arg_feeds import ArgFeeds
 from pdr_backend.ppss.lake_ss import LakeSS, lake_ss_test_dict
-from pdr_backend.util.time_types import UnixTimeMs
+from pdr_backend.util.time_types import UnixTimeMs, _dt_now_UTC
 
 _D = {
     "feeds": ["kraken ETH/USDT 5m", "binanceus ETH/USDT,TRX/DAI 1h"],
@@ -64,6 +65,19 @@ def test_lake_ss_now():
 
     ut2 = UnixTimeMs.from_timestr("now")
     assert ss.fin_timestamp / 1000 == pytest.approx(ut2 / 1000, 1.0)
+
+
+@enforce_types
+def test_lake_ss_start_time():
+    d = copy.deepcopy(_D)
+    d["st_timestr"] = "3 days ago"
+    d["fin_timestr"] = "now"
+    ss = LakeSS(d)
+
+    assert ss.st_timestr == "3 days ago"
+
+    ut2 = _dt_now_UTC() - timedelta(days=3)
+    assert ss.st_timestamp / 1000 == pytest.approx(ut2.timestamp(), 1.0)
 
 
 @enforce_types

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import dateparser
 from enforce_typing import enforce_types
 
 
@@ -47,13 +48,18 @@ class UnixTimeMs(int):
         return UnixTimeMs(int(dt.timestamp() * 1000))
 
     @staticmethod
-    def from_timestr(timestr: str) -> "UnixTimeMs":
-        if timestr.lower() == "now":
-            return UnixTimeMs.now()
+    def from_natural_language(nat_lang: str) -> "UnixTimeMs":
+        dt = dateparser.parse(nat_lang).replace(tzinfo=timezone.utc)
+        return UnixTimeMs(dt.timestamp() * 1000)
 
+    @staticmethod
+    def from_timestr(timestr: str) -> "UnixTimeMs":
         ncolon = timestr.count(":")
         if ncolon == 0:
-            dt = datetime.strptime(timestr, "%Y-%m-%d")
+            try:
+                dt = datetime.strptime(timestr, "%Y-%m-%d")
+            except ValueError:
+                return UnixTimeMs.from_natural_language(timestr)
         elif ncolon == 1:
             dt = datetime.strptime(timestr, "%Y-%m-%d_%H:%M")
         elif ncolon == 2:

--- a/ppss.yaml
+++ b/ppss.yaml
@@ -5,11 +5,11 @@ lake_ss:
     - binance BTC/USDT ETH/USDT 5m
   #    - binance BTC/USDT ETH/USDT BNB/USDT XRP/USDT ADA/USDT DOGE/USDT SOL/USDT LTC/USDT TRX/USDT DOT/USDT 5m
   #    - kraken BTC/USDT 5m
-  st_timestr: 2023-06-01_00:00 # starting date for data
+  st_timestr: 18 days ago # starting date for data
   fin_timestr: now # ending date for data
 
 predictoor_ss:
-  predict_train_feedsets: 
+  predict_train_feedsets:
     - predict: binance BTC/USDT ETH/USDT c 5m
       train_on:
       - binance BTC/USDT ETH/USDT c 5m
@@ -21,7 +21,7 @@ predictoor_ss:
     revenue: 0.93006 # Sales revenue going towards predictoors. In OCEAN per epoch, per feed. Calcs: 37500 OCEAN/week/20_feeds (Predictoor DF rewards) = 18.6012 OCEAN/epoch/20_feeds (bc 2016 5m epochs/week) = 0.93006 OCEAN/epoch/feed
 
   bot_only:
-    pred_submitter_mgr: "DeployNewMgr" # DeployNewMgr | <address of deployed mgr>  
+    pred_submitter_mgr: "DeployNewMgr" # DeployNewMgr | <address of deployed mgr>
     s_start_payouts: 220 # in s. Run payout if > this time left. 0 to disable
     s_until_epoch_end: 60 # in s. Start predicting if > this time left
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requirements = [
     "ccxt==4.3.11",
     "coverage",
     "dash==2.17.0",
+    "dateparser==1.2.0",
     "enforce_typing",
     "eth-account==0.11.0",
     "eth-keys==0.5.1",


### PR DESCRIPTION
Closes #1003. Part of main, but can be rebased into the ETL branch as well.

This PR leverages natural language-defined dates for UnixTimeMs.
It uses https://pypi.org/project/dateparser/ a well-known, tested and stable parser that handles time definition through strings. The original ticket suggests "now - 18 days" but this works on the standard notation as "18 days ago". I think it is much more feasible and extensible in this way, and support for "now" is inbuilt. I only run this parsing when no colons exist, so it only applies to this corner case in particular.