### PR TITLE
fix prepare temp tables fails if production table has no values

### DIFF
--- a/pdr_backend/cli/cli_module_lake.py
+++ b/pdr_backend/cli/cli_module_lake.py
@@ -62,7 +62,7 @@ def do_lake_query(args, ppss):
 
 @enforce_types
 def do_lake_raw_drop(args, ppss):
-    pds = PersistentDataStore(ppss, read_only=False)
+    pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
     drop_tables_from_st(pds, "raw", args.ST)
 
 
@@ -86,7 +86,7 @@ def do_lake_raw_update(_, ppss):
 
 @enforce_types
 def do_lake_etl_drop(args, ppss):
-    pds = PersistentDataStore(ppss, read_only=False)
+    pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
     drop_tables_from_st(pds, "etl", args.ST)
 
 

--- a/pdr_backend/cli/test/test_cli_module_lake.py
+++ b/pdr_backend/cli/test/test_cli_module_lake.py
@@ -75,11 +75,12 @@ def test_do_lake_query(caplog):
 
     mock_pds = Mock()
     mock_pds.query_data.return_value = "query result"
+    mock_ppss = Mock()
 
     with patch(
         "pdr_backend.cli.cli_module_lake.PersistentDataStore", return_value=mock_pds
     ):
-        do_lake_query(args, None)
+        do_lake_query(args, mock_ppss)
 
     mock_pds.query_data.assert_called_once_with(query)
 
@@ -89,7 +90,7 @@ def test_do_lake_query(caplog):
     with patch(
         "pdr_backend.cli.cli_module_lake.PersistentDataStore", return_value=mock_pds_err
     ):
-        do_lake_query(args, None)
+        do_lake_query(args, mock_ppss)
 
     assert "Error querying lake: boom!" in caplog.text
 
@@ -160,8 +161,10 @@ def test_do_lake_raw_drop(tmpdir, caplog):
     _make_and_fill_timestamps(pds, "test2", ts - 2 * one_day)
     _make_and_fill_timestamps(pds, "_etl_bronze_test", ts - 2 * one_day)
 
+    mock_ppss = Mock()
+
     with patch("pdr_backend.cli.cli_module_lake.PersistentDataStore", return_value=pds):
-        do_lake_raw_drop(args, None)
+        do_lake_raw_drop(args, mock_ppss)
 
     assert "drop table _temp_test1 starting at 1609459200000" in caplog.text
     assert "rows before: 5" in caplog.text
@@ -188,8 +191,10 @@ def test_do_lake_etl_drop(tmpdir, caplog):
     _make_and_fill_timestamps(pds, "_etl_silver_test2", ts - 2 * one_day)
     _make_and_fill_timestamps(pds, "_etl_test_raw", ts - 2 * one_day)
 
+    mock_ppss = Mock()
+
     with patch("pdr_backend.cli.cli_module_lake.PersistentDataStore", return_value=pds):
-        do_lake_etl_drop(args, None)
+        do_lake_etl_drop(args, mock_ppss)
 
     assert "drop table _temp_bronze_test1 starting at 1609459200000" in caplog.text
     assert "rows before: 5" in caplog.text

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -119,15 +119,24 @@ class GQLDataFactory:
         if csv_last_timestamp is None:
             return
 
-        if db_last_timestamp is None:
+        if (db_last_timestamp is None) or (
+            db_last_timestamp['max("timestamp")'][0] is None
+        ):
             logger.info("  Table not yet created. Insert all %s csv data", table_name)
             data = CSVDataStore(table.base_path).read_all(table_name, schema)
             table._append_to_db(data, TableType.TEMP)
             return
 
-        if csv_last_timestamp > db_last_timestamp['max("timestamp")'][0]:
+        if db_last_timestamp['max("timestamp")'][0] and (
+            csv_last_timestamp > db_last_timestamp['max("timestamp")'][0]
+        ):
             logger.info("  Table exists. Insert pending %s csv data", table_name)
-            data = CSVDataStore(table.base_path).read(table_name, st_ut, fin_ut, schema)
+            data = CSVDataStore(table.base_path).read(
+                table_name,
+                st_ut,
+                fin_ut,
+                schema,
+            )
             table._append_to_db(data, TableType.TEMP)
 
     @enforce_types


### PR DESCRIPTION
Fixes #1038.

- [x] Fixed `lake raw drop` and `lake etl drop` so that they both work with `pdr lake raw drop ppss.yaml sapphire-network 2023-01-01`
- [x] You can now drop rows from raw, or etl, and then resume building from where you left off, getting all the data loaded from the CSV
- [x] You can very quickly execute different loops of: 
1. update raw and view results, then drop part of raw: `raw update -> describe -> raw drop partial`
2. update raw again and verify it went to full: `raw update (to full) -> describe (see full)`
3. now update etl (to build full bronze tables) -> describe (see full bronze tables)
4. now run `lake raw update` to get latest from gql and sync raw data to duckdb
5. then run `lake etl update` to update the bronze tables based on the latest data you just fetched... only processing the new rows that have been fetched.
6. or you can `lake etl drop` everything, then run `lake etl update` and have your bronze tables rebuild in a second.
- [x] ETL is using the right etl_tables (start_ts) and raw_tables (end_ts) mixture to calculate how to process data, and only process the new data required. Both bronze SQL queries also enforce this.

![image](https://github.com/oceanprotocol/pdr-backend/assets/69865342/075bbef4-8d40-4f31-909b-a0e36e039208)
