### PR TITLE
Csv datastore simplification

### DIFF
--- a/pdr_backend/lake/csv_data_store.py
+++ b/pdr_backend/lake/csv_data_store.py
@@ -117,14 +117,14 @@ def _get_from_value(file_path: str) -> int:
     raise ValueError(f"File {file_path} does not contain a 'from' value")
 
 
-class CSVDSIdentifier:
+class CSVDataStore:
     def __init__(self, base_path: str, dataset_identifier: str):
         self.base_path = base_path
         self.dataset_identifier = dataset_identifier
 
     @staticmethod
     def from_table(table):
-        return CSVDSIdentifier(table.base_path, table.table_name)
+        return CSVDataStore(table.base_path, table.table_name)
 
     @enforce_types
     def _create_file_name(self, start_time: int, end_time: Optional[int]) -> str:

--- a/pdr_backend/lake/csv_data_store.py
+++ b/pdr_backend/lake/csv_data_store.py
@@ -213,7 +213,7 @@ class CSVDataStore(BaseDataStore):
         identifier = CSVDSIdentifier(self, dataset_identifier)
         file_path = identifier._get_last_file_path()
 
-        if not len(file_path):
+        if not file_path:
             return None
 
         to_value = CSVDataStore._get_to_value(file_path)
@@ -315,7 +315,7 @@ class CSVDSIdentifier:
         """
         last_file_path = self._get_last_file_path()
 
-        if not len(last_file_path):
+        if not last_file_path:
             return None
 
         # Read the last file

--- a/pdr_backend/lake/csv_data_store.py
+++ b/pdr_backend/lake/csv_data_store.py
@@ -5,226 +5,8 @@ import polars as pl
 from enforce_typing import enforce_types
 from polars.type_aliases import SchemaDict
 
-from pdr_backend.lake.base_data_store import BaseDataStore
 
-
-class CSVDataStore(BaseDataStore):
-    def write(
-        self,
-        dataset_identifier: str,
-        data: pl.DataFrame,
-        schema: Optional[SchemaDict] = None,
-    ):
-        """
-        Writes the given data to a csv file in the folder
-        corresponding to the given dataset_identifier.
-        @args:
-            data: pl.DataFrame - The data to write, it has to be sorted by timestamp
-            dataset_identifier: str - The dataset identifier
-        """
-        max_row_count = 1000
-        identifier = CSVDSIdentifier(self, dataset_identifier)
-        data = data.sort("timestamp")
-        data = identifier._append_remaining_rows(data, max_row_count, schema)
-
-        chunks = [
-            data.slice(i, min(max_row_count, len(data) - i))
-            for i in range(0, len(data), max_row_count)
-        ]
-
-        for i, chunk in enumerate(chunks):
-            start_time = int(chunk["timestamp"][0])
-            end_time = int(chunk["timestamp"][-1])
-            file_path = identifier._create_file_path(
-                start_time,
-                end_time if len(chunk) >= max_row_count else None,
-            )
-            chunk.write_csv(file_path)
-
-    def read(
-        self,
-        dataset_identifier: str,
-        start_time: int,
-        end_time: int,
-        schema: Optional[SchemaDict] = None,
-        filter_args: Optional[bool] = True,
-    ) -> pl.DataFrame:
-        """
-        Reads the data from the csv file in the folder
-        corresponding to the given dataset_identifier,
-        start_time, and end_time.
-        @args:
-            dataset_identifier: str - identifier of the dataset
-            start_time: int - start time of the data
-            end_time: int - end time of the data
-        @returns:
-            pl.DataFrame - data read from the csv file
-        """
-        data = self.read_all(dataset_identifier, schema=schema)
-        # if the data is empty, return
-        if len(data) == 0:
-            return data
-
-        # if the data is not empty,
-        # check the timestamp column exists and is of type int64
-        if "timestamp" not in data.columns or filter_args is False:
-            return data
-
-        return data.filter(
-            (data["timestamp"] >= start_time) & (data["timestamp"] <= end_time)
-        ).rechunk()
-
-    def read_all(
-        self, dataset_identifier: str, schema: Optional[SchemaDict] = None
-    ) -> pl.DataFrame:
-        """
-        Reads all the data from the csv files in the folder
-        corresponding to the given dataset_identifier.
-        @args:
-            dataset_identifier: str - identifier of the dataset
-        @returns:
-            pl.DataFrame - data read from the csv files
-        """
-        identifier = CSVDSIdentifier(self, dataset_identifier)
-        folder_path = identifier._get_folder_path()
-        file_names = os.listdir(folder_path)
-        file_paths = [os.path.join(folder_path, file_name) for file_name in file_names]
-        file_paths.sort()
-
-        if not file_paths:
-            return pl.DataFrame([], schema=schema)
-
-        # Read the first file to create the DataFrame
-        data = pl.read_csv(file_paths[0], schema=schema)
-        # Read the remaining files and append them to the DataFrame
-        for file_path in file_paths[1:]:
-            data = data.vstack(pl.read_csv(file_path, schema=schema))
-
-        return data
-
-    @staticmethod
-    @enforce_types
-    def _get_to_value(file_path: str) -> Union[int, None]:
-        """
-        Returns the end time from the given file_path.
-
-        This tries to solve for tables with variable name lengths.
-        Table 1: "pdr_predictions"
-        Table 2: "gold_summary_predictions_by_day"
-
-        However, if a table has the keyword "from" or "to" it will fai.
-
-        A better way to do this, would be to search back from end.
-        split("_")[-1] = "1701503000000.csv"
-        split("_")[-2] = "to"
-        split("_")[-3] = "1701500000000"
-        split("_")[-4] = "from"
-
-        It's possible that csv files do not contain a to_value.
-        In this case, the function returns None.
-
-        @args:
-            file_path: str - path of the file
-        @returns:
-            Union[int,None] - end time from the file_path
-        """
-        # let's split the string by "/" to get the last element
-        file_signature = file_path.split("/")[-1]
-
-        # let's find the "from" index inside the string split
-        signature_str_split = file_signature.split("_")
-
-        # let's find the from index and value
-        from_index, to_index = None, None
-        from_index = next(
-            (
-                index
-                for index, str_value in enumerate(signature_str_split)
-                if "from" in str_value
-            ),
-            None,
-        )
-
-        if from_index is not None:
-            from_index += 1
-            to_index = from_index + 2
-
-        if from_index is None or to_index is None:
-            return None
-
-        # if to_index is out of bounds, return None
-        if to_index >= len(signature_str_split):
-            return None
-
-        # if to_index is not out of bounds, but only `_to_.csv` there is no to_value, return None
-        to_value = signature_str_split[to_index].replace(".csv", "")
-        if to_value == "":
-            return None
-
-        # return the to_value
-        return int(to_value)
-
-    @staticmethod
-    @enforce_types
-    def _get_from_value(file_path: str) -> int:
-        """
-        Returns the start time from the given file_path.
-        @args:
-            file_path: str - path of the file
-        @returns:
-            int - start time from the file_path
-        """
-        # suppose the following file path
-        # "folder1/folder2/pdr_predictions_from_1701503000000_to_1701503000000.csv"
-        # now, we want to split the string, and then find
-        # if there is a "from" value and a "to" value
-        # keep in mind that the "to" value can be missing,
-        # if the file hasn't yet closed due to row limit
-
-        # let's split the string by "/" to get the last element
-        file_signature = file_path.split("/")[-1]
-
-        # let's find the "from" index inside the string split
-        signature_str_split = file_signature.split("_")
-
-        # let's find the from index and value
-        from_index = next(
-            (
-                index
-                for index, str_value in enumerate(signature_str_split)
-                if "from" in str_value
-            ),
-            None,
-        )
-
-        if from_index is not None:
-            return int(signature_str_split[from_index + 1])
-
-        raise ValueError(f"File {file_path} does not contain a 'from' value")
-
-    @enforce_types
-    def get_last_timestamp(self, dataset_identifier: str) -> Optional[int]:
-        """
-        Returns the last timestamp from the last csv files in the folder
-        corresponding to the given dataset_identifier.
-        @returns:
-            Optional[int] - last timestamp from the csv files
-        """
-        identifier = CSVDSIdentifier(self, dataset_identifier)
-        file_path = identifier._get_last_file_path()
-
-        if not file_path:
-            return None
-
-        to_value = CSVDataStore._get_to_value(file_path)
-        if to_value is not None and to_value > 0:
-            return to_value
-
-        # read the last record from the file
-        last_file = pl.read_csv(file_path)
-        return int(last_file["timestamp"][-1])
-
-
+@enforce_types
 def _pad_with_zeroes(number: int, length: int = 10) -> str:
     """
     Pads the given number with zeros to make it 10 digits long.
@@ -235,15 +17,114 @@ def _pad_with_zeroes(number: int, length: int = 10) -> str:
     return number_str.rjust(length, "0")
 
 
+@enforce_types
+def _get_to_value(file_path: str) -> Union[int, None]:
+    """
+    Returns the end time from the given file_path.
+
+    This tries to solve for tables with variable name lengths.
+    Table 1: "pdr_predictions"
+    Table 2: "gold_summary_predictions_by_day"
+
+    However, if a table has the keyword "from" or "to" it will fai.
+
+    A better way to do this, would be to search back from end.
+    split("_")[-1] = "1701503000000.csv"
+    split("_")[-2] = "to"
+    split("_")[-3] = "1701500000000"
+    split("_")[-4] = "from"
+
+    It's possible that csv files do not contain a to_value.
+    In this case, the function returns None.
+
+    @args:
+        file_path: str - path of the file
+    @returns:
+        Union[int,None] - end time from the file_path
+    """
+    # let's split the string by "/" to get the last element
+    file_signature = file_path.split("/")[-1]
+
+    # let's find the "from" index inside the string split
+    signature_str_split = file_signature.split("_")
+
+    # let's find the from index and value
+    from_index, to_index = None, None
+    from_index = next(
+        (
+            index
+            for index, str_value in enumerate(signature_str_split)
+            if "from" in str_value
+        ),
+        None,
+    )
+
+    if from_index is not None:
+        from_index += 1
+        to_index = from_index + 2
+
+    if from_index is None or to_index is None:
+        return None
+
+    # if to_index is out of bounds, return None
+    if to_index >= len(signature_str_split):
+        return None
+
+    # if to_index is not out of bounds, but only `_to_.csv` there is no to_value, return None
+    to_value = signature_str_split[to_index].replace(".csv", "")
+    if to_value == "":
+        return None
+
+    # return the to_value
+    return int(to_value)
+
+
+@enforce_types
+def _get_from_value(file_path: str) -> int:
+    """
+    Returns the start time from the given file_path.
+    @args:
+        file_path: str - path of the file
+    @returns:
+        int - start time from the file_path
+    """
+    # suppose the following file path
+    # "folder1/folder2/pdr_predictions_from_1701503000000_to_1701503000000.csv"
+    # now, we want to split the string, and then find
+    # if there is a "from" value and a "to" value
+    # keep in mind that the "to" value can be missing,
+    # if the file hasn't yet closed due to row limit
+
+    # let's split the string by "/" to get the last element
+    file_signature = file_path.split("/")[-1]
+
+    # let's find the "from" index inside the string split
+    signature_str_split = file_signature.split("_")
+
+    # let's find the from index and value
+    from_index = next(
+        (
+            index
+            for index, str_value in enumerate(signature_str_split)
+            if "from" in str_value
+        ),
+        None,
+    )
+
+    if from_index is not None:
+        return int(signature_str_split[from_index + 1])
+
+    raise ValueError(f"File {file_path} does not contain a 'from' value")
+
+
 class CSVDSIdentifier:
-    def __init__(self, csvds: CSVDataStore, dataset_identifier: str):
-        self.base_path = csvds.base_path
+    def __init__(self, base_path: str, dataset_identifier: str):
+        self.base_path = base_path
         self.dataset_identifier = dataset_identifier
-        self.csvds = csvds
 
     @staticmethod
     def from_table(table):
-        return CSVDSIdentifier(CSVDataStore(table.base_path), table.table_name)
+        return CSVDSIdentifier(table.base_path, table.table_name)
 
     @enforce_types
     def _create_file_name(self, start_time: int, end_time: Optional[int]) -> str:
@@ -367,6 +248,105 @@ class CSVDSIdentifier:
 
         return data.slice(remaining_rows, len(data) - remaining_rows)
 
+    def read_all(self, schema: Optional[SchemaDict] = None) -> pl.DataFrame:
+        """
+        Reads all the data from the csv files in the folder
+        corresponding to the given dataset_identifier.
+        @returns:
+            pl.DataFrame - data read from the csv files
+        """
+        file_paths = self.get_file_paths()
+
+        if not file_paths:
+            return pl.DataFrame([], schema=schema)
+
+        # Read the first file to create the DataFrame
+        data = pl.read_csv(file_paths[0], schema=schema)
+        # Read the remaining files and append them to the DataFrame
+        for file_path in file_paths[1:]:
+            data = data.vstack(pl.read_csv(file_path, schema=schema))
+
+        return data.rechunk()
+
+    def read(
+        self,
+        start_time: int,
+        end_time: int,
+        schema: Optional[SchemaDict] = None,
+        filter_args: Optional[bool] = True,
+    ) -> pl.DataFrame:
+        """
+        Reads the data from the csv file in the folder
+        corresponding to the given dataset_identifier,
+        start_time, and end_time.
+        @args:
+            dataset_identifier: str - identifier of the dataset
+            start_time: int - start time of the data
+            end_time: int - end time of the data
+        @returns:
+            pl.DataFrame - data read from the csv file
+        """
+        data = self.read_all(schema=schema)
+        # if the data is empty, return
+        if len(data) == 0:
+            return data
+
+        # if the data is not empty,
+        # check the timestamp column exists and is of type int64
+        if "timestamp" not in data.columns or filter_args is False:
+            return data
+
+        return data.filter(
+            (data["timestamp"] >= start_time) & (data["timestamp"] <= end_time)
+        ).rechunk()
+
+    def write(
+        self,
+        data: pl.DataFrame,
+        schema: Optional[SchemaDict] = None,
+    ):
+        """
+        Writes the given data to a csv file in the folder
+        corresponding to the given dataset_identifier.
+        @args:
+            data: pl.DataFrame - The data to write, it has to be sorted by timestamp
+            dataset_identifier: str - The dataset identifier
+        """
+        max_row_count = 1000
+        data = data.sort("timestamp")
+        data = self._append_remaining_rows(data, max_row_count, schema)
+
+        chunks = [
+            data.slice(i, min(max_row_count, len(data) - i))
+            for i in range(0, len(data), max_row_count)
+        ]
+
+        for i, chunk in enumerate(chunks):
+            start_time = int(chunk["timestamp"][0])
+            end_time = int(chunk["timestamp"][-1])
+            file_path = self._create_file_path(
+                start_time,
+                end_time if len(chunk) >= max_row_count else None,
+            )
+            chunk.write_csv(file_path)
+
     @enforce_types
     def get_last_timestamp(self) -> Optional[int]:
-        return self.csvds.get_last_timestamp(self.dataset_identifier)
+        """
+        Returns the last timestamp from the last csv files in the folder
+        corresponding to the given dataset_identifier.
+        @returns:
+            Optional[int] - last timestamp from the csv files
+        """
+        file_path = self._get_last_file_path()
+
+        if not file_path:
+            return None
+
+        to_value = _get_to_value(file_path)
+        if to_value is not None and to_value > 0:
+            return to_value
+
+        # read the last record from the file
+        last_file = pl.read_csv(file_path)
+        return int(last_file["timestamp"][-1])

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict
 import polars as pl
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
+from pdr_backend.lake.csv_data_store import CSVDataStore, CSVDSIdentifier
 from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.plutil import _object_list_to_df
@@ -109,9 +109,7 @@ class GQLDataFactory:
             # 3. check conditions and move to temp tables
         """
         table = TableRegistry().get_table(table_name)
-        csv_last_timestamp = CSVDataStore(table.base_path).get_last_timestamp(
-            table_name
-        )
+        csv_last_timestamp = CSVDSIdentifier.from_table(table).get_last_timestamp()
         db_last_timestamp = PersistentDataStore(table.base_path).query_data(
             f"SELECT MAX(timestamp) FROM {table_name}"
         )
@@ -153,9 +151,7 @@ class GQLDataFactory:
             start_ut - timestamp (ut) to start grabbing data for (in ms)
         """
 
-        last_timestamp = CSVDataStore(table.base_path).get_last_timestamp(
-            table.table_name
-        )
+        last_timestamp = CSVDSIdentifier.from_table(table).get_last_timestamp()
 
         start_ut = (
             last_timestamp
@@ -287,7 +283,6 @@ class GQLDataFactory:
         @arguments
             fin_ut -- a timestamp, in ms, in UTC
         """
-
         for table in (
             TableRegistry().get_tables(self.record_config["gql_tables"]).values()
         ):

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict
 import polars as pl
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore, CSVDSIdentifier
+from pdr_backend.lake.csv_data_store import CSVDSIdentifier
 from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.plutil import _object_list_to_df
@@ -121,7 +121,7 @@ class GQLDataFactory:
             db_last_timestamp['max("timestamp")'][0] is None
         ):
             logger.info("  Table not yet created. Insert all %s csv data", table_name)
-            data = CSVDataStore(table.base_path).read_all(table_name, schema)
+            data = CSVDSIdentifier.from_table(table).read_all(schema)
             table._append_to_db(data, TableType.TEMP)
             return
 
@@ -129,8 +129,7 @@ class GQLDataFactory:
             csv_last_timestamp > db_last_timestamp['max("timestamp")'][0]
         ):
             logger.info("  Table exists. Insert pending %s csv data", table_name)
-            data = CSVDataStore(table.base_path).read(
-                table_name,
+            data = CSVDSIdentifier.from_table(table).read(
                 st_ut,
                 fin_ut,
                 schema,

--- a/pdr_backend/lake/lake_validate.py
+++ b/pdr_backend/lake/lake_validate.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 import polars as pl
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.etl import ETL
 from pdr_backend.lake.gql_data_factory import GQLDataFactory
 from pdr_backend.lake.lake_info import LakeInfo
@@ -28,7 +27,6 @@ class LakeValidate(LakeInfo):
         }
         self.results: Dict[str, List[str]] = {}
 
-        self.csvds = CSVDataStore(ppss.lake_ss.lake_dir)
         self.gql_data_factory = GQLDataFactory(ppss)
         self.etl = ETL(ppss, self.gql_data_factory)
 

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -5,7 +5,7 @@ from typing import Optional
 import polars as pl
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
+from pdr_backend.lake.csv_data_store import CSVDSIdentifier
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.ppss.ppss import PPSS
 
@@ -97,10 +97,9 @@ class Table:
         @arguments:
             data - The Polars DataFrame to save.
         """
-        csvds = CSVDataStore(self.base_path)
+        csvds = CSVDSIdentifier.from_table(self)
         logger.info(" csvds = %s", csvds)
         csvds.write(
-            self.table_name,
             data,
             schema=self.dataclass.get_lake_schema(),  # type: ignore[attr-defined]
         )

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -5,7 +5,7 @@ from typing import Optional
 import polars as pl
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDSIdentifier
+from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.ppss.ppss import PPSS
 
@@ -97,7 +97,7 @@ class Table:
         @arguments:
             data - The Polars DataFrame to save.
         """
-        csvds = CSVDSIdentifier.from_table(self)
+        csvds = CSVDataStore.from_table(self)
         logger.info(" csvds = %s", csvds)
         csvds.write(
             data,

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -5,7 +5,7 @@ import polars as pl
 import pytest
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
+from pdr_backend.lake.csv_data_store import CSVDataStore, CSVDSIdentifier
 from pdr_backend.lake.etl import ETL
 from pdr_backend.lake.payout import Payout, mock_payout, mock_payouts
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
@@ -86,6 +86,14 @@ def _get_test_CSVDS():
         return CSVDataStore(str(tmpdir))
 
     return create_csv_datastore
+
+
+@pytest.fixture()
+def _get_test_CSVDSIdentifier():
+    def create_csv_datastore_identifier(tmpdir, name):
+        return CSVDSIdentifier(CSVDataStore(str(tmpdir)), name)
+
+    return create_csv_datastore_identifier
 
 
 # pylint: disable=line-too-long

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -5,7 +5,7 @@ import polars as pl
 import pytest
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDSIdentifier
+from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.etl import ETL
 from pdr_backend.lake.payout import Payout, mock_payout, mock_payouts
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
@@ -81,9 +81,9 @@ def _get_test_PDS():
 
 
 @pytest.fixture()
-def _get_test_CSVDSIdentifier():
+def _get_test_CSVDataStore():
     def create_csv_datastore_identifier(tmpdir, name):
-        return CSVDSIdentifier(tmpdir, name)
+        return CSVDataStore(tmpdir, name)
 
     return create_csv_datastore_identifier
 

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -5,7 +5,7 @@ import polars as pl
 import pytest
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.csv_data_store import CSVDataStore, CSVDSIdentifier
+from pdr_backend.lake.csv_data_store import CSVDSIdentifier
 from pdr_backend.lake.etl import ETL
 from pdr_backend.lake.payout import Payout, mock_payout, mock_payouts
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
@@ -81,17 +81,9 @@ def _get_test_PDS():
 
 
 @pytest.fixture()
-def _get_test_CSVDS():
-    def create_csv_datastore(tmpdir):
-        return CSVDataStore(str(tmpdir))
-
-    return create_csv_datastore
-
-
-@pytest.fixture()
 def _get_test_CSVDSIdentifier():
     def create_csv_datastore_identifier(tmpdir, name):
-        return CSVDSIdentifier(CSVDataStore(str(tmpdir)), name)
+        return CSVDSIdentifier(tmpdir, name)
 
     return create_csv_datastore_identifier
 

--- a/pdr_backend/lake/test/test_csv_data_store.py
+++ b/pdr_backend/lake/test/test_csv_data_store.py
@@ -9,33 +9,33 @@ from pdr_backend.lake.csv_data_store import (
 )
 
 
-def test_get_folder_path(_get_test_CSVDSIdentifier, tmpdir):
-    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_get_folder_path(_get_test_CSVDataStore, tmpdir):
+    csv_ds_identifier = _get_test_CSVDataStore(tmpdir, "test")
     folder_path = csv_ds_identifier._get_folder_path()
     assert folder_path == f"{tmpdir}/test"
 
 
-def test_create_file_name(_get_test_CSVDSIdentifier, tmpdir):
-    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_create_file_name(_get_test_CSVDataStore, tmpdir):
+    csv_ds_identifier = _get_test_CSVDataStore(tmpdir, "test")
     file_name = csv_ds_identifier._create_file_name(1707030362, 1709060200)
     print("file_name---", file_name)
     assert file_name == "test_from_1707030362_to_1709060200.csv"
 
 
-def test_create_file_path(_get_test_CSVDSIdentifier, tmpdir):
-    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_create_file_path(_get_test_CSVDataStore, tmpdir):
+    csv_ds_identifier = _get_test_CSVDataStore(tmpdir, "test")
     file_path = csv_ds_identifier._create_file_path(1, 2)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_0000000002.csv"
 
 
-def test_create_file_path_without_endtime(_get_test_CSVDSIdentifier, tmpdir):
-    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_create_file_path_without_endtime(_get_test_CSVDataStore, tmpdir):
+    csv_ds_identifier = _get_test_CSVDataStore(tmpdir, "test")
     file_path = csv_ds_identifier._create_file_path(1, None)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_.csv"
 
 
-def test_read(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_read(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
     file_path = identifier._create_file_path(1, 2)
 
     with open(file_path, "w") as file:
@@ -45,8 +45,8 @@ def test_read(_get_test_CSVDSIdentifier, tmpdir):
     assert data.equals(pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]}))
 
 
-def test_read_all(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_read_all(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
 
     file_path_1 = identifier._create_file_path(0, 20)
     file_path_2 = identifier._create_file_path(21, 41)
@@ -63,8 +63,8 @@ def test_read_all(_get_test_CSVDSIdentifier, tmpdir):
     assert data["c"].to_list() == [3, 6, 9, 12]
 
 
-def test_get_last_file_path(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_get_last_file_path(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
 
     file_path_1 = identifier._create_file_path(0, 20)
     file_path_2 = identifier._create_file_path(21, 41)
@@ -86,8 +86,8 @@ def test_get_last_file_path(_get_test_CSVDSIdentifier, tmpdir):
     assert identifier._get_last_file_path() == os.path.join(folder_path, file_path_4)
 
 
-def test_write(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_write(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
 
     identifier.write(data)
@@ -101,8 +101,8 @@ def test_write(_get_test_CSVDSIdentifier, tmpdir):
     assert data["timestamp"].to_list() == [3, 6]
 
 
-def test_write_1000_rows(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_write_1000_rows(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
     data = pl.DataFrame(
         {
             "a": list(range(1000)),
@@ -127,8 +127,8 @@ def test_write_1000_rows(_get_test_CSVDSIdentifier, tmpdir):
     assert data["timestamp"].to_list() == list(range(1000))
 
 
-def test_write_append(_get_test_CSVDSIdentifier, tmpdir):
-    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+def test_write_append(_get_test_CSVDataStore, tmpdir):
+    identifier = _get_test_CSVDataStore(tmpdir, "test")
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
     identifier.write(data)
 

--- a/pdr_backend/lake/test/test_csv_data_store.py
+++ b/pdr_backend/lake/test/test_csv_data_store.py
@@ -3,8 +3,8 @@ import os
 import polars as pl
 
 from pdr_backend.lake.csv_data_store import (
-    CSVDataStore,
-    CSVDSIdentifier,
+    _get_from_value,
+    _get_to_value,
     _pad_with_zeroes,
 )
 
@@ -34,21 +34,19 @@ def test_create_file_path_without_endtime(_get_test_CSVDSIdentifier, tmpdir):
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_.csv"
 
 
-def test_read(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    identifier = CSVDSIdentifier(csv_data_store, "test")
+def test_read(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
     file_path = identifier._create_file_path(1, 2)
 
     with open(file_path, "w") as file:
         file.write("a,b,c\n1,2,3\n4,5,6")
 
-    data = csv_data_store.read("test", 1, 2)
+    data = identifier.read(1, 2)
     assert data.equals(pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]}))
 
 
-def test_read_all(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    identifier = CSVDSIdentifier(csv_data_store, "test")
+def test_read_all(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
 
     file_path_1 = identifier._create_file_path(0, 20)
     file_path_2 = identifier._create_file_path(21, 41)
@@ -59,15 +57,14 @@ def test_read_all(_get_test_CSVDS, tmpdir):
     with open(file_path_2, "w") as file:
         file.write("a,b,c\n7,8,9\n10,11,12")
 
-    data = csv_data_store.read_all("test")
+    data = identifier.read_all()
     assert data["a"].to_list() == [1, 4, 7, 10]
     assert data["b"].to_list() == [2, 5, 8, 11]
     assert data["c"].to_list() == [3, 6, 9, 12]
 
 
-def test_get_last_file_path(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    identifier = CSVDSIdentifier(csv_data_store, "test")
+def test_get_last_file_path(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
 
     file_path_1 = identifier._create_file_path(0, 20)
     file_path_2 = identifier._create_file_path(21, 41)
@@ -89,12 +86,12 @@ def test_get_last_file_path(_get_test_CSVDS, tmpdir):
     assert identifier._get_last_file_path() == os.path.join(folder_path, file_path_4)
 
 
-def test_write(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
+def test_write(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
-    csv_data_store.write("test", data)
 
-    identifier = CSVDSIdentifier(csv_data_store, "test")
+    identifier.write(data)
+
     file_name = identifier._create_file_path(3, None)
 
     data = pl.read_csv(file_name)
@@ -104,8 +101,8 @@ def test_write(_get_test_CSVDS, tmpdir):
     assert data["timestamp"].to_list() == [3, 6]
 
 
-def test_write_1000_rows(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
+def test_write_1000_rows(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
     data = pl.DataFrame(
         {
             "a": list(range(1000)),
@@ -113,7 +110,7 @@ def test_write_1000_rows(_get_test_CSVDS, tmpdir):
             "timestamp": list(range(1000)),
         }
     )
-    csv_data_store.write("test", data)
+    identifier.write(data)
 
     # folder_path = csv_data_store._get_folder_path("test")
 
@@ -122,9 +119,7 @@ def test_write_1000_rows(_get_test_CSVDS, tmpdir):
     # print folder files
     # print("folder---", folder)
 
-    identifier = CSVDSIdentifier(csv_data_store, "test")
     file_name = identifier._create_file_path(0, 999)
-
     data = pl.read_csv(file_name)
 
     assert data["a"].to_list() == list(range(1000))
@@ -132,16 +127,15 @@ def test_write_1000_rows(_get_test_CSVDS, tmpdir):
     assert data["timestamp"].to_list() == list(range(1000))
 
 
-def test_write_append(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
+def test_write_append(_get_test_CSVDSIdentifier, tmpdir):
+    identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
-    csv_data_store.write("test", data)
+    identifier.write(data)
 
     # new data
     data = pl.DataFrame({"a": [11, 41], "b": [21, 51], "timestamp": [31, 61]})
-    csv_data_store.write("test", data)
+    identifier.write(data)
 
-    identifier = CSVDSIdentifier(csv_data_store, "test")
     file_name = identifier._create_file_path(3, 61)
 
     data = pl.read_csv(file_name)
@@ -158,43 +152,10 @@ def test_pad_with_zeroes():
 
 
 def test_get_to_value():
-    csv_data_store = CSVDataStore("test")
-    assert csv_data_store._get_to_value("test/test_from_0_to_0000000001.csv") == 1
-    assert csv_data_store._get_to_value("test/test_from_0_to_0000000005.csv") == 5
+    assert _get_to_value("test/test_from_0_to_0000000001.csv") == 1
+    assert _get_to_value("test/test_from_0_to_0000000005.csv") == 5
 
 
 def test_get_from_value():
-    csv_data_store = CSVDataStore("test")
-    assert (
-        csv_data_store._get_from_value("test/test_from_0000000001_to_0000000001.csv")
-        == 1
-    )
-    assert csv_data_store._get_from_value("test/test_from_0000000005_to_.csv") == 5
-
-
-def test_multiton_instances():
-    """
-    This test is to check if the instances of
-    the CSVDataStore are the same
-    """
-    CSVDataStore.clear_instances()
-    csv_data_store_1 = CSVDataStore("test")
-    csv_data_store_2 = CSVDataStore("test")
-    assert csv_data_store_1 == csv_data_store_2
-    assert csv_data_store_1 is csv_data_store_2
-    assert csv_data_store_1.base_path == csv_data_store_2.base_path
-    assert csv_data_store_1._instances == csv_data_store_2._instances
-
-
-def test_multiton_instances_different_base_path():
-    """
-    This test is to check if the instances of
-    the CSVDataStore are different
-    """
-    CSVDataStore.clear_instances()
-    csv_data_store_1 = CSVDataStore("test")
-    csv_data_store_2 = CSVDataStore("test2")
-    assert csv_data_store_1 != csv_data_store_2
-    assert csv_data_store_1 is not csv_data_store_2
-    assert csv_data_store_1.base_path != csv_data_store_2.base_path
-    assert csv_data_store_1._instances == csv_data_store_2._instances
+    assert _get_from_value("test/test_from_0000000001_to_0000000001.csv") == 1
+    assert _get_from_value("test/test_from_0000000005_to_.csv") == 5

--- a/pdr_backend/lake/test/test_csv_data_store.py
+++ b/pdr_backend/lake/test/test_csv_data_store.py
@@ -1,37 +1,43 @@
 import os
 
 import polars as pl
-from pdr_backend.lake.csv_data_store import CSVDataStore
+
+from pdr_backend.lake.csv_data_store import (
+    CSVDataStore,
+    CSVDSIdentifier,
+    _pad_with_zeroes,
+)
 
 
-def test_get_folder_path(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    folder_path = csv_data_store._get_folder_path("test")
+def test_get_folder_path(_get_test_CSVDSIdentifier, tmpdir):
+    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+    folder_path = csv_ds_identifier._get_folder_path()
     assert folder_path == f"{tmpdir}/test"
 
 
-def test_create_file_name(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    file_name = csv_data_store._create_file_name("test", 1707030362, 1709060200)
+def test_create_file_name(_get_test_CSVDSIdentifier, tmpdir):
+    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+    file_name = csv_ds_identifier._create_file_name(1707030362, 1709060200)
     print("file_name---", file_name)
     assert file_name == "test_from_1707030362_to_1709060200.csv"
 
 
-def test_create_file_path(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    file_path = csv_data_store._create_file_path("test", 1, 2)
+def test_create_file_path(_get_test_CSVDSIdentifier, tmpdir):
+    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+    file_path = csv_ds_identifier._create_file_path(1, 2)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_0000000002.csv"
 
 
-def test_create_file_path_without_endtime(_get_test_CSVDS, tmpdir):
-    csv_data_store = _get_test_CSVDS(tmpdir)
-    file_path = csv_data_store._create_file_path("test", 1, None)
+def test_create_file_path_without_endtime(_get_test_CSVDSIdentifier, tmpdir):
+    csv_ds_identifier = _get_test_CSVDSIdentifier(tmpdir, "test")
+    file_path = csv_ds_identifier._create_file_path(1, None)
     assert file_path == f"{tmpdir}/test/test_from_0000000001_to_.csv"
 
 
 def test_read(_get_test_CSVDS, tmpdir):
     csv_data_store = _get_test_CSVDS(tmpdir)
-    file_path = csv_data_store._create_file_path("test", 1, 2)
+    identifier = CSVDSIdentifier(csv_data_store, "test")
+    file_path = identifier._create_file_path(1, 2)
 
     with open(file_path, "w") as file:
         file.write("a,b,c\n1,2,3\n4,5,6")
@@ -42,9 +48,10 @@ def test_read(_get_test_CSVDS, tmpdir):
 
 def test_read_all(_get_test_CSVDS, tmpdir):
     csv_data_store = _get_test_CSVDS(tmpdir)
+    identifier = CSVDSIdentifier(csv_data_store, "test")
 
-    file_path_1 = csv_data_store._create_file_path("test", 0, 20)
-    file_path_2 = csv_data_store._create_file_path("test", 21, 41)
+    file_path_1 = identifier._create_file_path(0, 20)
+    file_path_2 = identifier._create_file_path(21, 41)
 
     with open(file_path_1, "w") as file:
         file.write("a,b,c\n1,2,3\n4,5,6")
@@ -60,14 +67,16 @@ def test_read_all(_get_test_CSVDS, tmpdir):
 
 def test_get_last_file_path(_get_test_CSVDS, tmpdir):
     csv_data_store = _get_test_CSVDS(tmpdir)
-    file_path_1 = csv_data_store._create_file_path("test", 0, 20)
-    file_path_2 = csv_data_store._create_file_path("test", 21, 41)
-    file_path_3 = csv_data_store._create_file_path("test", 42, 62)
-    file_path_4 = csv_data_store._create_file_path("test", 63, 83)
+    identifier = CSVDSIdentifier(csv_data_store, "test")
+
+    file_path_1 = identifier._create_file_path(0, 20)
+    file_path_2 = identifier._create_file_path(21, 41)
+    file_path_3 = identifier._create_file_path(42, 62)
+    file_path_4 = identifier._create_file_path(63, 83)
 
     files = [file_path_1, file_path_2, file_path_3, file_path_4]
 
-    folder_path = csv_data_store._get_folder_path("test")
+    folder_path = identifier._get_folder_path()
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
@@ -77,16 +86,16 @@ def test_get_last_file_path(_get_test_CSVDS, tmpdir):
         with open(os.path.join(folder_path, file), "w"):
             pass
 
-    assert csv_data_store._get_last_file_path(f"{tmpdir}/test") == os.path.join(
-        folder_path, file_path_4
-    )
+    assert identifier._get_last_file_path() == os.path.join(folder_path, file_path_4)
 
 
 def test_write(_get_test_CSVDS, tmpdir):
     csv_data_store = _get_test_CSVDS(tmpdir)
     data = pl.DataFrame({"a": [1, 4], "b": [2, 5], "timestamp": [3, 6]})
     csv_data_store.write("test", data)
-    file_name = csv_data_store._create_file_path("test", 3, None)
+
+    identifier = CSVDSIdentifier(csv_data_store, "test")
+    file_name = identifier._create_file_path(3, None)
 
     data = pl.read_csv(file_name)
 
@@ -113,7 +122,8 @@ def test_write_1000_rows(_get_test_CSVDS, tmpdir):
     # print folder files
     # print("folder---", folder)
 
-    file_name = csv_data_store._create_file_path("test", 0, 999)
+    identifier = CSVDSIdentifier(csv_data_store, "test")
+    file_name = identifier._create_file_path(0, 999)
 
     data = pl.read_csv(file_name)
 
@@ -131,7 +141,8 @@ def test_write_append(_get_test_CSVDS, tmpdir):
     data = pl.DataFrame({"a": [11, 41], "b": [21, 51], "timestamp": [31, 61]})
     csv_data_store.write("test", data)
 
-    file_name = csv_data_store._create_file_path("test", 3, 61)
+    identifier = CSVDSIdentifier(csv_data_store, "test")
+    file_name = identifier._create_file_path(3, 61)
 
     data = pl.read_csv(file_name)
 
@@ -141,10 +152,9 @@ def test_write_append(_get_test_CSVDS, tmpdir):
 
 
 def test_pad_with_zeroes():
-    csv_data_store = CSVDataStore("test")
-    assert csv_data_store._pad_with_zeroes(1, 10) == "0000000001"
-    assert csv_data_store._pad_with_zeroes(100) == "0000000100"
-    assert csv_data_store._pad_with_zeroes(1000) == "0000001000"
+    assert _pad_with_zeroes(1, 10) == "0000000001"
+    assert _pad_with_zeroes(100) == "0000000100"
+    assert _pad_with_zeroes(1000) == "0000001000"
 
 
 def test_get_to_value():

--- a/pdr_backend/lake/test/test_persistent_data_store.py
+++ b/pdr_backend/lake/test/test_persistent_data_store.py
@@ -5,7 +5,6 @@ import time
 import duckdb
 import polars as pl
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.table import ETLTable, NamedTable, TempTable
 
@@ -187,16 +186,6 @@ def test_multiton_instances_with_different_base_paths(tmpdir):
     persistent_data_store_2 = PersistentDataStore(different_path)
 
     assert id(persistent_data_store_1) != id(persistent_data_store_2)
-
-
-def test_multiton_with_CSVDataStore(tmpdir):
-    persistent_data_store_1 = PersistentDataStore(str(tmpdir))
-    csv_data_store_1 = CSVDataStore(str(tmpdir))
-
-    assert id(persistent_data_store_1) != id(csv_data_store_1)
-
-    # test cls._instances so that it is not the same
-    assert persistent_data_store_1._instances != csv_data_store_1._instances
 
 
 def test__duckdb_connection(tmpdir):

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -3,7 +3,7 @@ import os
 import polars as pl
 from polars import Boolean, Float64, Int64, Utf8
 
-from pdr_backend.lake.csv_data_store import CSVDataStore
+from pdr_backend.lake.csv_data_store import CSVDSIdentifier
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.prediction import Prediction
 from pdr_backend.lake.table import Table
@@ -116,7 +116,7 @@ def test_csv_data_store(
     table = Table(Prediction, ppss)
     table._append_to_csv(_gql_datafactory_first_predictions_df)
 
-    assert CSVDataStore(table.base_path).has_data(Prediction.get_lake_table_name())
+    assert CSVDSIdentifier.from_table(table).has_data()
 
     csv_file_path = os.path.join(
         ppss.lake_ss.lake_dir,

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -3,7 +3,7 @@ import os
 import polars as pl
 from polars import Boolean, Float64, Int64, Utf8
 
-from pdr_backend.lake.csv_data_store import CSVDSIdentifier
+from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.prediction import Prediction
 from pdr_backend.lake.table import Table
@@ -116,7 +116,7 @@ def test_csv_data_store(
     table = Table(Prediction, ppss)
     table._append_to_csv(_gql_datafactory_first_predictions_df)
 
-    assert CSVDSIdentifier.from_table(table).has_data()
+    assert CSVDataStore.from_table(table).has_data()
 
     csv_file_path = os.path.join(
         ppss.lake_ss.lake_dir,


### PR DESCRIPTION
To follow-up on the booleans issue (ref #1015 and maybe #973)

Added rechunks and simplified data management for identifiers. Adds utility to create CSV identifiers from tables directly, but keep CSVDataStore for inspection purposes as well.