### PR TITLE
Fix Issue1058: Update validation-tool - Validate against duplicate rows

### DIFF
--- a/pdr_backend/cli/cli_module_lake.py
+++ b/pdr_backend/cli/cli_module_lake.py
@@ -51,8 +51,9 @@ def do_lake_query(args, ppss):
     @description
         Query the lake for a table or view
     """
-    pds = PersistentDataStore(ppss, read_only=True)
+    pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=True)
     try:
+        print(f"Querying lake...:[{args.QUERY}]")
         df = pds.query_data(args.QUERY)
         print(df)
     except Exception as e:

--- a/pdr_backend/lake/lake_info.py
+++ b/pdr_backend/lake/lake_info.py
@@ -42,6 +42,10 @@ class LakeInfo:
             columns = []
             has_timestamp = False
 
+            if len(source[table_name]) == 0:
+                print("Table is empty. Please drop it.")
+                continue
+
             for col in source[table_name].iter_columns():
                 if col.name == "timestamp":
                     has_timestamp = True

--- a/pdr_backend/lake/lake_info.py
+++ b/pdr_backend/lake/lake_info.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from datetime import datetime
 
 import polars as pl
 from polars.dataframe.frame import DataFrame
@@ -32,7 +33,9 @@ class LakeInfo:
                 "SELECT * FROM {}".format(view_name)
             )
 
-    def print_table_info(self, source: Dict[str, DataFrame]):
+    def print_table_info(self, source_name: str, source: Dict[str, DataFrame]):
+        table_summary = pl.DataFrame()
+
         for table_name in source:
             print("-" * 80)
             print("Columns for table {}:".format(table_name), end=" ")
@@ -49,28 +52,74 @@ class LakeInfo:
             if has_timestamp:
                 min_timestamp = source[table_name]["timestamp"].min()
                 max_timestamp = source[table_name]["timestamp"].max()
-                
+
+                if isinstance(min_timestamp, (int, float)):
+                    min_datestr = datetime.fromtimestamp(
+                        min_timestamp / 1000.0
+                    ).strftime("%d-%m-%Y %H:%M:%S")
+                else:
+                    min_datestr = None
+
+                if isinstance(max_timestamp, (int, float)):
+                    max_datestr = datetime.fromtimestamp(
+                        max_timestamp / 1000.0
+                    ).strftime("%d-%m-%Y %H:%M:%S")
+                else:
+                    max_datestr = None
+
+                n_rows = len(source[table_name])
+
                 if min_timestamp is not None:
                     print("Min timestamp: " + str(min_timestamp))
                 if max_timestamp is not None:
                     print("Max timestamp: " + str(max_timestamp))
 
+                if min_datestr is not None:
+                    print("Min datestr: " + str(min_datestr))
+                if max_datestr is not None:
+                    print("Max datestr: " + str(max_datestr))
+
+                if n_rows > 0:
+                    print("Number of rows: {}".format(n_rows))
+
+                table_info = pl.DataFrame(
+                    {
+                        "table_name": [table_name],
+                        "n_rows": [n_rows],
+                        "min_timestamp": [min_timestamp],
+                        "max_timestamp": [max_timestamp],
+                        "min_datestr": [min_datestr],
+                        "max_datestr": [max_datestr],
+                    }
+                )
+                table_summary = pl.concat([table_summary, table_info])
             else:
                 print("No timestamp data")
 
-            shape = source[table_name].shape
-            print(f"Number of rows: {shape[0]}")
-
-            print("Preview: \n")
+            print("Preview")
             print(source[table_name])
+
+        with pl.Config(tbl_rows=100):
+            print("=" * 80)
+
+            print("Summary - {}".format(source_name))
+            print(table_summary)
 
     def run(self):
         self.generate()
-        print("Lake Tables:")
-        print(self.all_table_names)
-        self.print_table_info(self.table_info)
+
+        if len(self.all_table_names) == 0:
+            print("No Lake Tables")
+        else:
+            print("Lake Tables:")
+            print(self.all_table_names)
+            self.print_table_info("tables", self.table_info)
 
         print("=" * 80)
-        print("Lake Views:")
-        print(self.all_view_names)
-        self.print_table_info(self.view_info)
+
+        if len(self.all_view_names) == 0:
+            print("Great - No views in Lake.")
+        else:
+            print("Lake Views:")
+            print(self.all_view_names)
+            self.print_table_info("views", self.view_info)

--- a/pdr_backend/lake/lake_info.py
+++ b/pdr_backend/lake/lake_info.py
@@ -47,11 +47,16 @@ class LakeInfo:
             print(",".join(columns))
 
             if has_timestamp:
+                min_timestamp = source[table_name]["timestamp"].min()
                 max_timestamp = source[table_name]["timestamp"].max()
+                
+                if min_timestamp is not None:
+                    print("Min timestamp: " + str(min_timestamp))
                 if max_timestamp is not None:
                     print("Max timestamp: " + str(max_timestamp))
-                else:
-                    print("No timestamp data")
+
+            else:
+                print("No timestamp data")
 
             shape = source[table_name].shape
             print(f"Number of rows: {shape[0]}")

--- a/pdr_backend/lake/lake_validate.py
+++ b/pdr_backend/lake/lake_validate.py
@@ -24,6 +24,7 @@ class LakeValidate(LakeInfo):
             "validate_tables_in_lake": self.validate_expected_table_names,
             "validate_no_views_in_lake": self.validate_expected_view_names,
             "validate_no_gaps_in_bronze_predictions": self.validate_lake_bronze_predictions_gaps,
+            "validate_no_duplicates_in_lake": self.validate_lake_tables_no_duplicates,
         }
         self.results: Dict[str, List[str]] = {}
 
@@ -171,7 +172,78 @@ class LakeValidate(LakeInfo):
             with pl.Config(tbl_rows=100):
                 logger.info("%s Gap Report\n%s", table_name, gap_pct)
 
-            violations.append("Gap validation failed. Please review logs.")
+            violations.append("Gap validation failed.")
+
+        return violations
+
+    @enforce_types
+    def validate_lake_tables_no_duplicates(self) -> List[str]:
+        """
+        description:
+            Validate that there are no duplicate rows in the lake tables using a single column
+            For every duplicate in a table log 1 row w/: table_name, id, date, count_duplicates
+            
+            This function logs a table with the following columns:
+            - table_name, count_duplicates
+            
+            You can call write_csv(validate_no_duplicats.csv) to get a report.
+        """
+        violations = []
+        duplicate_summary = pl.DataFrame()
+        duplicate_rows = pl.DataFrame()
+        
+        query_duplicate_summary = """
+            SELECT
+                'target_table' as table_name,
+                COUNT(*) as incident_count
+            FROM (
+                SELECT
+                    ID as ID,
+                    timestamp,
+                FROM target_table
+                GROUP BY ID, timestamp
+                HAVING COUNT(*) > 1                
+            ) as inner_query
+            GROUP BY table_name
+        """
+
+        for table_name in self.all_table_names:
+            query = query_duplicate_summary.replace("target_table", table_name)
+            summary_df: pl.DataFrame = self.pds.query_data(query)
+            
+            if summary_df.shape[0] > 0:
+                # if we do have duplicates, we will get the duplicate rows and append them, so they can be written out
+                # get the rows that have a dupplicate count > 1 (known_duplicates)
+                # and then join them with the table_rows, so we can get all the individual rows
+                query_duplicate_rows = """
+                    SELECT
+                        'target_table' as table_name,
+                        target_table.ID,
+                        target_table.timestamp
+                    FROM (
+                        SELECT
+                            ID as ID,
+                            timestamp,
+                        FROM target_table
+                        GROUP BY ID, timestamp
+                        HAVING COUNT(*) > 1                
+                    ) as known_duplicates
+                    LEFT JOIN target_table
+                    ON known_duplicates.ID = target_table.ID
+                """
+
+                query = query_duplicate_rows.replace("target_table", table_name)
+                rows_df: pl.DataFrame = self.pds.query_data(query)
+                duplicate_rows = duplicate_rows.vstack(rows_df)
+            
+                duplicate_summary = duplicate_summary.vstack(summary_df)
+                violations.append(f"Table {table_name} has duplicates.")
+
+        logger.info("Duplicate Summary\n%s", duplicate_summary)
+        logger.info("Duplicate Rows:\n%s", duplicate_rows)
+
+        # enable if you need to write out and debug
+        # duplicate_rows.write_csv("validate_no_duplicates.csv")
 
         return violations
 


### PR DESCRIPTION
Fixes #1058 

TODOs / DoD
Expand validation tool such that it tests for duplicate rows, and provides a report about duplicate rows/validations.

Tasks:
- [x] Write duplicate row queries
- [x] Aggregate results so we can write a report
- [x] Generate a report based on tables & output
- [x] Write duplicate validation errors & messages
- [x] User is able to easily get a duplicate report at the lake level, across all tables
- [x] User is able to easily get a report at the row level, across all tables
- [x] Updated lake describe to: report st_ts, end_ts, also in datestr format (st_ts_datestr, end_ts_datestr)
- [x] Updated lake describe to provide a single summary across all tables so we can eventually put it on a dashboard (rather than outputting 12x different results that are hard to stitch together)
- [ ] User is able to easily drop rows and rebuild clean lake
- [ ] Write tests showing this validation is working as intended

What we're not addressing in this PR:
- Understanding why the duplicate rows are showing up
- To address this, we should continue to debug the lake, write tests, improve fixtures, and continue writing e2e coverage