### PR TITLE
[DuckDB][GQL] Fix Issue1068 - Keep fixed end_ts across all table updates + fetches

### DIFF
--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -285,12 +285,13 @@ class GQLDataFactory:
         @arguments
             fin_ut -- a timestamp, in ms, in UTC
         """
+        fin_ut = self.ppss.lake_ss.fin_timestamp
+
         for table in (
             TableRegistry().get_tables(self.record_config["gql_tables"]).values()
         ):
             # calculate start and end timestamps
             st_ut = self._calc_start_ut(table)
-            fin_ut = self.ppss.lake_ss.fin_timestamp
             logger.info(
                 "      Aim to fetch data from start time: %s", st_ut.pretty_timestr()
             )


### PR DESCRIPTION
Fixes #1068 

![image](https://github.com/oceanprotocol/pdr-backend/assets/69865342/255bbae5-bb43-4597-91ee-0586a186420c)

Changes proposed in this PR:
- [x] Keep end_ts fixed across all tables during GQLDF procedure