### PR TITLE
Fix Issue1070 - Unix time natural_language: "now" and other commands are generating local time

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -62,6 +62,9 @@ ignore_missing_imports = True
 [mypy-pytest]
 ignore_missing_imports = True
 
+[mypy-pytz.*]
+ignore_missing_imports = True
+
 [mypy-sapphirepy.*]
 ignore_missing_imports = True
 

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -295,7 +295,7 @@ class GQLDataFactory:
             logger.info(
                 "      Aim to fetch data from start_time: [%s] to end_time: [%s]",
                 st_ut.pretty_timestr(),
-                fin_ut.pretty_timestr()
+                fin_ut.pretty_timestr(),
             )
             if st_ut > min(UnixTimeMs.now(), fin_ut):
                 logger.info("      Given start time, no data to gather. Exit.")

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -285,12 +285,13 @@ class GQLDataFactory:
         @arguments
             fin_ut -- a timestamp, in ms, in UTC
         """
+        fin_ut = self.ppss.lake_ss.fin_timestamp
+
         for table in (
             TableRegistry().get_tables(self.record_config["gql_tables"]).values()
         ):
             # calculate start and end timestamps
             st_ut = self._calc_start_ut(table)
-            fin_ut = self.ppss.lake_ss.fin_timestamp
             logger.info(
                 "      Aim to fetch data from start time: %s", st_ut.pretty_timestr()
             )

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -293,7 +293,9 @@ class GQLDataFactory:
             # calculate start and end timestamps
             st_ut = self._calc_start_ut(table)
             logger.info(
-                "      Aim to fetch data from start time: %s", st_ut.pretty_timestr()
+                "      Aim to fetch data from start_time: [%s] to end_time: [%s]",
+                st_ut.pretty_timestr(),
+                fin_ut.pretty_timestr()
             )
             if st_ut > min(UnixTimeMs.now(), fin_ut):
                 logger.info("      Given start time, no data to gather. Exit.")

--- a/pdr_backend/ppss/test/test_timestamp.py
+++ b/pdr_backend/ppss/test/test_timestamp.py
@@ -2,21 +2,22 @@ from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
 from datetime import datetime
 import time
 
+
 def test_time_ms(tmpdir):
     # from lake_ss line 76
     ms_end_ts_from_timestr_now = UnixTimeMs.from_timestr("now")
-    
+
     # from app.py line 237
-    ms_end_ts_from_utc = UnixTimeMs(int(datetime.utcnow().timestamp())) #in seconds
-    s_end_ts_from_utc = UnixTimeS(int(datetime.utcnow().timestamp())) #in seconds
-    
+    ms_end_ts_from_utc = UnixTimeMs(int(datetime.utcnow().timestamp()))  # in seconds
+    s_end_ts_from_utc = UnixTimeS(int(datetime.utcnow().timestamp()))  # in seconds
+
     # unix timestamp
     print(">>> ms_end_ts_from_timestr_now", ms_end_ts_from_timestr_now)
-    
+
     # timestamp from datetime utcnow()... which is in the future... and wrong
     print(">>> ms_end_ts_from_utc", ms_end_ts_from_utc)
     print(">>> s_end_ts_from_utc", s_end_ts_from_utc)
-    
+
     # just vanilla python unix timestamp
     print(">>> time.time()", int(time.time()))
 
@@ -33,7 +34,7 @@ def test_time_ms(tmpdir):
     # Assert that unix time is in the future, from UnixTimeMs and UnixTimeS, which are local time
     assert int(time.time()) != UnixTimeMs.now().to_seconds()
     assert int(time.time()) != UnixTimeS.now()
-    
+
     # Assert these two are the same
     assert UnixTimeMs.now().to_seconds() == UnixTimeS.now()
 

--- a/pdr_backend/ppss/test/test_timestamp.py
+++ b/pdr_backend/ppss/test/test_timestamp.py
@@ -1,44 +1,39 @@
-from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
 from datetime import datetime
-import time
+
+from freezegun import freeze_time
+
+from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
 
 
-def test_time_ms(tmpdir):
-    # from lake_ss line 76
-    ms_end_ts_from_timestr_now = UnixTimeMs.from_timestr("now")
+# value is in UTC, timezone of system will be -5
+@freeze_time("2024-01-01 13:00:00", tz_offset=-5)
+def test_time_now_implicit():
+    assert datetime.now().isoformat() == "2024-01-01T08:00:00"
+    assert datetime.utcnow().isoformat() == "2024-01-01T13:00:00"
 
-    # from app.py line 237
-    ms_end_ts_from_utc = UnixTimeMs(int(datetime.utcnow().timestamp()))  # in seconds
-    s_end_ts_from_utc = UnixTimeS(int(datetime.utcnow().timestamp()))  # in seconds
+    now_ms = UnixTimeMs.now()
+    assert int(now_ms) == 1704114000000  # corresponds to 2024-01-01 13:00:00 UTC
 
-    # unix timestamp
-    print(">>> ms_end_ts_from_timestr_now", ms_end_ts_from_timestr_now)
+    now_s = UnixTimeS.now()
+    assert int(now_s) == 1704114000  # corresponds to 2024-01-01 13:00:00 UTC
 
-    # timestamp from datetime utcnow()... which is in the future... and wrong
-    print(">>> ms_end_ts_from_utc", ms_end_ts_from_utc)
-    print(">>> s_end_ts_from_utc", s_end_ts_from_utc)
 
-    # just vanilla python unix timestamp
-    print(">>> time.time()", int(time.time()))
+# needed because it takes a couple of ms to run instructions in the test
+def _close_ints(x, y):
+    return abs(x - y) <= 2
 
-    # UnixTimeMs now
-    print(">>> UnixTimeMs.now()", UnixTimeMs.now())
 
-    # UnixTimeS now
-    print(">>> UnixTimeS.now()", UnixTimeS.now())
+# can not use freezegun fixtures because it does not work with dateparser
+def test_time_now_natural_language():
+    assert _close_ints(int(UnixTimeMs.from_timestr("now")), int(UnixTimeMs.now()))
+    assert _close_ints(
+        int(UnixTimeMs.from_timestr("an hour ago")), int(UnixTimeMs.now()) - 3600000
+    )
+    assert _close_ints(
+        int(UnixTimeMs.from_timestr("in one hour")), int(UnixTimeMs.now()) + 3600000
+    )
 
-    assert ms_end_ts_from_timestr_now > 0
-    assert ms_end_ts_from_utc > 0
-    assert time.time() > 0
-
-    # Assert that unix time is in the future, from UnixTimeMs and UnixTimeS, which are local time
-    assert int(time.time()) != UnixTimeMs.now().to_seconds()
-    assert int(time.time()) != UnixTimeS.now()
-
-    # Assert these two are the same
-    assert UnixTimeMs.now().to_seconds() == UnixTimeS.now()
-
-    # Assert whatever app.py is doing... is wrong
-    assert ms_end_ts_from_utc == ms_end_ts_from_utc
-    assert ms_end_ts_from_utc > UnixTimeMs.now().to_seconds()
-    assert s_end_ts_from_utc > UnixTimeS.now()
+    assert _close_ints(
+        int(UnixTimeMs.from_timestr("18 days ago")),
+        int(UnixTimeMs.now()) - 3600000 * 24 * 18,
+    )

--- a/pdr_backend/ppss/test/test_timestamp.py
+++ b/pdr_backend/ppss/test/test_timestamp.py
@@ -1,0 +1,43 @@
+from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
+from datetime import datetime
+import time
+
+def test_time_ms(tmpdir):
+    # from lake_ss line 76
+    ms_end_ts_from_timestr_now = UnixTimeMs.from_timestr("now")
+    
+    # from app.py line 237
+    ms_end_ts_from_utc = UnixTimeMs(int(datetime.utcnow().timestamp())) #in seconds
+    s_end_ts_from_utc = UnixTimeS(int(datetime.utcnow().timestamp())) #in seconds
+    
+    # unix timestamp
+    print(">>> ms_end_ts_from_timestr_now", ms_end_ts_from_timestr_now)
+    
+    # timestamp from datetime utcnow()... which is in the future... and wrong
+    print(">>> ms_end_ts_from_utc", ms_end_ts_from_utc)
+    print(">>> s_end_ts_from_utc", s_end_ts_from_utc)
+    
+    # just vanilla python unix timestamp
+    print(">>> time.time()", int(time.time()))
+
+    # UnixTimeMs now
+    print(">>> UnixTimeMs.now()", UnixTimeMs.now())
+
+    # UnixTimeS now
+    print(">>> UnixTimeS.now()", UnixTimeS.now())
+
+    assert ms_end_ts_from_timestr_now > 0
+    assert ms_end_ts_from_utc > 0
+    assert time.time() > 0
+
+    # Assert that unix time is in the future, from UnixTimeMs and UnixTimeS, which are local time
+    assert int(time.time()) != UnixTimeMs.now().to_seconds()
+    assert int(time.time()) != UnixTimeS.now()
+    
+    # Assert these two are the same
+    assert UnixTimeMs.now().to_seconds() == UnixTimeS.now()
+
+    # Assert whatever app.py is doing... is wrong
+    assert ms_end_ts_from_utc == ms_end_ts_from_utc
+    assert ms_end_ts_from_utc > UnixTimeMs.now().to_seconds()
+    assert s_end_ts_from_utc > UnixTimeS.now()

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -51,11 +51,10 @@ class UnixTimeMs(int):
     @staticmethod
     def from_natural_language(nat_lang: str) -> "UnixTimeMs":
         try:
-            dt = dateparser.parse(nat_lang)
-            if not dt.tzinfo:
-                dt = pytz.utc.localize(dt)
+            dt = dateparser.parse(nat_lang, settings={"RETURN_AS_TIMEZONE_AWARE": True})
+            dt = dt.astimezone(pytz.utc)
 
-            return UnixTimeMs(dt.timestamp() * 1000)
+            return UnixTimeMs.from_dt(dt)
         except AttributeError as e:
             raise ValueError(f"Could not parse {nat_lang}.") from e
 

--- a/pdr_backend/util/time_types.py
+++ b/pdr_backend/util/time_types.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 import dateparser
+import pytz
 from enforce_typing import enforce_types
 
 
@@ -50,7 +51,10 @@ class UnixTimeMs(int):
     @staticmethod
     def from_natural_language(nat_lang: str) -> "UnixTimeMs":
         try:
-            dt = dateparser.parse(nat_lang).replace(tzinfo=timezone.utc)
+            dt = dateparser.parse(nat_lang)
+            if not dt.tzinfo:
+                dt = pytz.utc.localize(dt)
+
             return UnixTimeMs(dt.timestamp() * 1000)
         except AttributeError as e:
             raise ValueError(f"Could not parse {nat_lang}.") from e
@@ -117,6 +121,6 @@ class UnixTimeMs(int):
 
 @enforce_types
 def _dt_now_UTC() -> datetime:
-    dt = datetime.now()
+    dt = datetime.utcnow()
     dt = dt.replace(tzinfo=timezone.utc)  # tack on timezone
     return dt


### PR DESCRIPTION
Fixes #1070

We're running into issues where UnixTimeS and UnixTimeMs respond w/ timestamps that should be in UTC, but in reality are in local time. This is causing all sorts of issues in the data.

Changes proposed in this PR:
- [x] Not yet fixed, I have created a test to show the problem
- [x] Using "now" should generate the correct timestamp (not local time, but UTC)