### PR TITLE
Fix Issue 1079: Enforce UnixTimeMs when dropping tables

### DIFF
--- a/pdr_backend/cli/cli_module_lake.py
+++ b/pdr_backend/cli/cli_module_lake.py
@@ -10,7 +10,6 @@ from pdr_backend.lake.lake_validate import LakeValidate
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.table import drop_tables_from_st
 from pdr_backend.ppss.ppss import PPSS
-from pdr_backend.util.time_types import UnixTimeMs
 
 logger = logging.getLogger("cli")
 
@@ -64,7 +63,7 @@ def do_lake_query(args, ppss):
 @enforce_types
 def do_lake_raw_drop(args, ppss):
     pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
-    drop_tables_from_st(pds, "raw", UnixTimeMs(args.ST))
+    drop_tables_from_st(pds, "raw", args.ST)
 
 
 @enforce_types
@@ -88,7 +87,7 @@ def do_lake_raw_update(_, ppss):
 @enforce_types
 def do_lake_etl_drop(args, ppss):
     pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
-    drop_tables_from_st(pds, "etl", UnixTimeMs(args.ST))
+    drop_tables_from_st(pds, "etl", args.ST)
 
 
 @enforce_types

--- a/pdr_backend/cli/cli_module_lake.py
+++ b/pdr_backend/cli/cli_module_lake.py
@@ -10,6 +10,7 @@ from pdr_backend.lake.lake_validate import LakeValidate
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.lake.table import drop_tables_from_st
 from pdr_backend.ppss.ppss import PPSS
+from pdr_backend.util.time_types import UnixTimeMs
 
 logger = logging.getLogger("cli")
 
@@ -63,7 +64,7 @@ def do_lake_query(args, ppss):
 @enforce_types
 def do_lake_raw_drop(args, ppss):
     pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
-    drop_tables_from_st(pds, "raw", args.ST)
+    drop_tables_from_st(pds, "raw", UnixTimeMs(args.ST))
 
 
 @enforce_types
@@ -87,7 +88,7 @@ def do_lake_raw_update(_, ppss):
 @enforce_types
 def do_lake_etl_drop(args, ppss):
     pds = PersistentDataStore(ppss.lake_ss.lake_dir, read_only=False)
-    drop_tables_from_st(pds, "etl", args.ST)
+    drop_tables_from_st(pds, "etl", UnixTimeMs(args.ST))
 
 
 @enforce_types

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -9,6 +9,7 @@ from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.lake_mapper import LakeMapper
 from pdr_backend.lake.persistent_data_store import PersistentDataStore
 from pdr_backend.ppss.ppss import PPSS
+from pdr_backend.util.time_types import UnixTimeMs
 
 logger = logging.getLogger("table")
 
@@ -35,7 +36,7 @@ def is_etl_table(table_name: str) -> bool:
 
 
 @enforce_types
-def drop_tables_from_st(pds: PersistentDataStore, type_filter: str, st):
+def drop_tables_from_st(pds: PersistentDataStore, type_filter: str, st: UnixTimeMs):
     trunc_count = table_count = 0
     if type_filter not in ["raw", "etl"]:
         return


### PR DESCRIPTION
Fixes #1079 

Currently, all records are being dropped because timestamp is not being cast to Ms... so everything is Ms > S.

Changes proposed in this PR:
- [x] Enforce UnixTimeMs in drop function, such that we drop the right timestamp
- [x] Update CLI commands to cast st_ts to UnixTimeMs
- [x] Drop CLI command is now fixed