### PR TITLE
Fix dynamic ppss start date causes issues

### DIFF
--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -227,7 +227,7 @@ class ETL:
         }
 
         if len(queries) == 0:
-            return none_values
+            return None
 
         final_query = " UNION ALL ".join(queries)
         result = DuckDBDataStore(self.ppss.lake_ss.lake_dir).query_data(final_query)
@@ -235,7 +235,7 @@ class ETL:
         logger.info("_get_min_timestamp_values_from - result: %s", result)
 
         if result is None:
-            return none_values
+            return None
 
         values: Dict[str, Optional[UnixTimeMs]] = {}
 
@@ -289,7 +289,14 @@ class ETL:
         st_timestr = self._get_min_timestamp_values_from(
             [NamedTable(tb) for tb in self.gql_data_factory.raw_table_names]
         )
-        from_timestamp = self.get_timestamp_values(self.bronze_table_names, st_timestr)
+        from_timestamp = self.get_timestamp_values(
+            self.bronze_table_names,
+            (
+                st_timestr
+                if st_timestr
+                else UnixTimeMs.from_timestr(self.ppss.lake_ss.st_timestr)
+            ),
+        )
 
         to_timestamp = self.get_timestamp_values(
             self.gql_data_factory.raw_table_names,

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -185,7 +185,7 @@ class ETL:
             values[table_name] = UnixTimeMs(max_timestamp) if max_timestamp else None
 
         return values
-    
+
     @enforce_types
     def _get_min_timestamp_values_from(
         self, tables: List[NamedTable]
@@ -273,9 +273,7 @@ class ETL:
             ]
 
         logger.info("get_timestamp_values - values: %s", values)
-        timestamp = (
-            max(values) if len(values) > 0 else default_timestr
-        )
+        timestamp = max(values) if len(values) > 0 else default_timestr
         return timestamp
 
     @enforce_types
@@ -288,13 +286,14 @@ class ETL:
             ETL updates should use to_timestamp by calculating
             min(max(source_tables_max_timestamp)).
         """
-        st_timestr = self._get_min_timestamp_values_from([NamedTable(tb) for tb in self.gql_data_factory.raw_table_names])
-        from_timestamp = self.get_timestamp_values(
-            self.bronze_table_names, st_timestr
+        st_timestr = self._get_min_timestamp_values_from(
+            [NamedTable(tb) for tb in self.gql_data_factory.raw_table_names]
         )
+        from_timestamp = self.get_timestamp_values(self.bronze_table_names, st_timestr)
 
         to_timestamp = self.get_timestamp_values(
-            self.gql_data_factory.raw_table_names, UnixTimeMs.from_timestr(self.ppss.lake_ss.fin_timestr)
+            self.gql_data_factory.raw_table_names,
+            UnixTimeMs.from_timestr(self.ppss.lake_ss.fin_timestr),
         )
 
         assert from_timestamp <= to_timestamp, (

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -193,7 +193,7 @@ def test_calc_start_ut(tmpdir):
     gql_data_factory = GQLDataFactory(ppss)
     table = TableRegistry().get_table("pdr_predictions")
 
-    st_ut = gql_data_factory._calc_start_ut(table)
+    st_ut = gql_data_factory._calc_start_ut(table, st_timestr)
     assert st_ut.to_seconds() == 1701561601
 
 


### PR DESCRIPTION
Fixes #1094.

### DoD:
- [ ] Figure out st_ts and end_ts before calling the pipeline. Then, call the pipeline with a fixed st_ts and end_ts, such that these parameters DO NOT CHANGE during the course of the ETL pipeline.
- [ ] Add checks/validations/asserts that (end-ts - st_ts) > 1 day. Anything below this, is a horrible configuration. If subgraph goes down for a day, this configuration fails.