### PR TITLE
More ETL removals, including Table

### DIFF
--- a/pdr_backend/analytics/test/test_get_predictions_info.py
+++ b/pdr_backend/analytics/test/test_get_predictions_info.py
@@ -6,7 +6,7 @@ from enforce_typing import enforce_types
 
 from pdr_backend.analytics.get_predictions_info import get_predictions_info_main
 from pdr_backend.lake.prediction import Prediction
-from pdr_backend.lake.table import Table
+from pdr_backend.lake.table import NamedTable
 from pdr_backend.ppss.ppss import mock_ppss
 
 
@@ -31,8 +31,8 @@ def test_get_predictions_info_main_mainnet(
         fin_timestr=fin_timestr,
     )
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -96,8 +96,8 @@ def test_get_predictions_info_bad_date_range(
     )
 
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -151,8 +151,8 @@ def test_get_predictions_info_bad_feed(
     )
 
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     feed_addr = "0x8e0we267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -193,9 +193,9 @@ def test_get_predictions_info_empty(_gql_datafactory_first_predictions_df, tmpdi
         fin_timestr=fin_timestr,
     )
 
-    predictions_table = Table(Prediction, ppss)
+    predictions_table = NamedTable.from_dataclass(Prediction)
     predictions_table.append_to_storage(
-        pl.DataFrame([], schema=Prediction.get_lake_schema())
+        pl.DataFrame([], schema=Prediction.get_lake_schema()), ppss
     )
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"

--- a/pdr_backend/analytics/test/test_get_predictoors_info.py
+++ b/pdr_backend/analytics/test/test_get_predictoors_info.py
@@ -6,7 +6,7 @@ from enforce_typing import enforce_types
 
 from pdr_backend.analytics.get_predictions_info import get_predictoors_info_main
 from pdr_backend.lake.prediction import Prediction
-from pdr_backend.lake.table import Table
+from pdr_backend.lake.table import NamedTable
 from pdr_backend.ppss.ppss import mock_ppss
 
 
@@ -28,8 +28,8 @@ def test_get_predictoors_info_main_mainnet(
     )
 
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     user_addr = "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd"
 
@@ -80,8 +80,8 @@ def test_get_predictoors_info_bad_date_range(
     )
 
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     user_addr = "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd"
 
@@ -130,8 +130,8 @@ def test_get_predictoors_info_bad_user_address(
     )
 
     predictions_df = _gql_datafactory_first_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     user_addr = "0xbbbb4cb4ff2584bad80ff5f109034a891c3d223"
 

--- a/pdr_backend/analytics/test/test_get_traction_info.py
+++ b/pdr_backend/analytics/test/test_get_traction_info.py
@@ -6,7 +6,7 @@ from enforce_typing import enforce_types
 
 from pdr_backend.analytics.get_predictions_info import get_traction_info_main
 from pdr_backend.lake.prediction import Prediction
-from pdr_backend.lake.table import Table
+from pdr_backend.lake.table import NamedTable
 from pdr_backend.ppss.ppss import mock_ppss
 
 
@@ -36,8 +36,8 @@ def test_get_traction_info_main_mainnet(
     )
 
     predictions_df = _gql_datafactory_daily_predictions_df
-    predictions_table = Table(Prediction, ppss)
-    predictions_table.append_to_storage(predictions_df)
+    predictions_table = NamedTable.from_dataclass(Prediction)
+    predictions_table.append_to_storage(predictions_df, ppss)
 
     get_traction_info_main(ppss, st_timestr, fin_timestr)
 
@@ -76,9 +76,9 @@ def test_get_traction_info_empty_data(
         fin_timestr=fin_timestr,
     )
 
-    pdr_prediction_table = Table(Prediction, ppss)
+    pdr_prediction_table = NamedTable.from_dataclass(Prediction)
     pdr_prediction_table.append_to_storage(
-        pl.DataFrame([], schema=Prediction.get_lake_schema())
+        pl.DataFrame([], schema=Prediction.get_lake_schema()), ppss
     )
 
     with pytest.raises(AssertionError):

--- a/pdr_backend/cli/cli_module_lake.py
+++ b/pdr_backend/cli/cli_module_lake.py
@@ -78,7 +78,7 @@ def do_lake_raw_update(_, ppss):
     """
     try:
         gql_data_factory = GQLDataFactory(ppss)
-        gql_data_factory.get_gql_tables()
+        gql_data_factory._update()
     except Exception as e:
         logger.error("Error updating raw lake data: %s", e)
         print(e)

--- a/pdr_backend/lake/csv_data_store.py
+++ b/pdr_backend/lake/csv_data_store.py
@@ -123,8 +123,8 @@ class CSVDataStore:
         self.table_name = table_name
 
     @staticmethod
-    def from_table(table):
-        return CSVDataStore(table.base_path, table.table_name)
+    def from_table(table, ppss):
+        return CSVDataStore(ppss.lake_ss.lake_dir, table.table_name)
 
     @enforce_types
     def _create_file_name(self, start_time: int, end_time: Optional[int]) -> str:

--- a/pdr_backend/lake/duckdb_data_store.py
+++ b/pdr_backend/lake/duckdb_data_store.py
@@ -195,7 +195,7 @@ class DuckDBDataStore(BaseDataStore):
                 "move_table_data - Table %s does not exist", temp_table.fullname
             )
 
-        permanent_table_name = permanent_table.table_name
+        permanent_table_name = permanent_table.fullname
         # check if the permanent table exists
         if permanent_table_name not in table_names:
             # create table if it does not exist

--- a/pdr_backend/lake/etl.py
+++ b/pdr_backend/lake/etl.py
@@ -5,7 +5,10 @@ from typing import Dict, List, Optional, Tuple
 from enforce_typing import enforce_types
 
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
-from pdr_backend.lake.gql_data_factory import GQLDataFactory
+from pdr_backend.lake.gql_data_factory import (
+    GQLDataFactory,
+    _GQLDF_REGISTERED_TABLE_NAMES,
+)
 from pdr_backend.lake.table import ETLTable, NamedTable, TempTable
 from pdr_backend.lake.table_bronze_pdr_predictions import BronzePrediction
 from pdr_backend.ppss.ppss import PPSS
@@ -86,7 +89,7 @@ class ETL:
             logger.info("do_etl - Drop build tables.")
 
             # Sync data
-            self.gql_data_factory.get_gql_tables()
+            self.gql_data_factory._update()
             logger.info("do_etl - Synced data. Start bronze_step.")
 
             self.do_bronze_step()
@@ -224,7 +227,7 @@ class ETL:
         )
 
         to_timestamp = self.get_timestamp_values(
-            self.gql_data_factory.raw_table_names, self.ppss.lake_ss.fin_timestr
+            _GQLDF_REGISTERED_TABLE_NAMES, self.ppss.lake_ss.fin_timestr
         )
 
         assert from_timestamp <= to_timestamp, (

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -10,7 +10,7 @@ from pdr_backend.lake.lake_mapper import LakeMapper
 from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.plutil import _object_list_to_df
 from pdr_backend.lake.prediction import Prediction
-from pdr_backend.lake.table import NamedTable, Table, TableType, TempTable
+from pdr_backend.lake.table import NamedTable, TempTable
 from pdr_backend.lake.table_pdr_predictions import _transform_timestamp_to_ms
 from pdr_backend.lake.trueval import Trueval
 from pdr_backend.ppss.ppss import PPSS
@@ -77,11 +77,14 @@ class GQLDataFactory:
             # 3. in preparation to append, check missing data to move FROM CSV -> TO TEMP TABLES
             # 4. resume appending to CSVs + Temp tables until complete
         """
-        table = Table(dataclass, self.ppss)
+        table = NamedTable.from_dataclass(dataclass)
+        temp_table = TempTable.from_dataclass(dataclass)
         schema = dataclass.get_lake_schema()
-        csv_last_timestamp = CSVDataStore.from_table(table).get_last_timestamp()
-        db_last_timestamp = DuckDBDataStore(table.base_path).query_data(
-            f"SELECT MAX(timestamp) FROM {table.table_name}"
+        csv_last_timestamp = CSVDataStore.from_table(
+            table, self.ppss
+        ).get_last_timestamp()
+        db_last_timestamp = DuckDBDataStore(self.ppss.lake_ss.lake_dir).query_data(
+            f"SELECT MAX(timestamp) FROM {table.fullname}"
         )
 
         if csv_last_timestamp is None:
@@ -91,25 +94,25 @@ class GQLDataFactory:
             db_last_timestamp['max("timestamp")'][0] is None
         ):
             logger.info(
-                "  Table not yet created. Insert all %s csv data", table.table_name
+                "  Table not yet created. Insert all %s csv data", table.fullname
             )
-            data = CSVDataStore.from_table(table).read_all(schema)
-            table._append_to_db(data, TableType.TEMP)
+            data = CSVDataStore.from_table(table, self.ppss).read_all(schema)
+            temp_table._append_to_db(data, self.ppss)
             return
 
         if db_last_timestamp['max("timestamp")'][0] and (
             csv_last_timestamp > db_last_timestamp['max("timestamp")'][0]
         ):
-            logger.info("  Table exists. Insert pending %s csv data", table.table_name)
-            data = CSVDataStore.from_table(table).read(
+            logger.info("  Table exists. Insert pending %s csv data", table.fullname)
+            data = CSVDataStore.from_table(table, self.ppss).read(
                 st_ut,
                 fin_ut,
                 schema,
             )
-            table._append_to_db(data, TableType.TEMP)
+            temp_table._append_to_db(data, self.ppss)
 
     @enforce_types
-    def _calc_start_ut(self, table: Table) -> UnixTimeMs:
+    def _calc_start_ut(self, table: NamedTable) -> UnixTimeMs:
         """
         @description
             Calculate start timestamp, reconciling whether file exists and where
@@ -122,7 +125,7 @@ class GQLDataFactory:
             start_ut - timestamp (ut) to start grabbing data for (in ms)
         """
 
-        last_timestamp = CSVDataStore.from_table(table).get_last_timestamp()
+        last_timestamp = CSVDataStore.from_table(table, self.ppss).get_last_timestamp()
 
         start_ut = (
             last_timestamp
@@ -149,8 +152,10 @@ class GQLDataFactory:
             Update function for graphql query, returns raw data
             + Transforms ts into ms as required for data factory
         """
-        table = Table(dataclass, self.ppss)
-        logger.info("Fetching data for %s", table.table_name)
+        table = NamedTable.from_dataclass(dataclass)
+        temp_table = TempTable.from_dataclass(dataclass)
+
+        logger.info("Fetching data for %s", table.fullname)
         network = get_sapphire_postfix(network)
 
         # save to file when this amount of data is fetched
@@ -160,7 +165,7 @@ class GQLDataFactory:
         buffer_df = pl.DataFrame([], schema=dataclass.get_lake_schema())
 
         DuckDBDataStore(self.ppss.lake_ss.lake_dir).create_table_if_not_exists(
-            TempTable.from_table(table).fullname,
+            temp_table.fullname,
             dataclass.get_lake_schema(),
         )
 
@@ -201,7 +206,7 @@ class GQLDataFactory:
                 save_backoff_count >= save_backoff_limit or len(df) < pagination_limit
             ) and len(buffer_df) > 0:
                 assert df.schema == dataclass.get_lake_schema()
-                table.append_to_storage(buffer_df, TableType.TEMP)
+                temp_table.append_to_storage(buffer_df, self.ppss)
                 logger.info(
                     "Saved %s records to storage while fetching", len(buffer_df)
                 )
@@ -220,7 +225,7 @@ class GQLDataFactory:
             pagination_offset += pagination_limit
 
         if len(buffer_df) > 0:
-            table.append_to_storage(buffer_df, TableType.TEMP)
+            temp_table.append_to_storage(buffer_df, self.ppss)
             logger.info("Saved %s records to storage while fetching", len(buffer_df))
 
     @enforce_types
@@ -259,7 +264,7 @@ class GQLDataFactory:
 
         for dataclass in _GQLDF_REGISTERED_LAKE_TABLES:
             # calculate start and end timestamps
-            table = Table(dataclass, self.ppss)
+            table = NamedTable.from_dataclass(dataclass)
             st_ut = self._calc_start_ut(table)
             logger.info(
                 "      Aim to fetch data from start_time: [%s] to end_time: [%s]",
@@ -273,7 +278,7 @@ class GQLDataFactory:
             self._prepare_temp_table(dataclass, st_ut, fin_ut)
 
             # fetch from subgraph and add to temp table
-            logger.info("Updating table %s", NamedTable.from_table(table).fullname)
+            logger.info("Updating table %s", table.fullname)
             self._do_subgraph_fetch(
                 dataclass,
                 self.ppss.web3_pp.network,

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
 import polars as pl
 from enforce_typing import enforce_types
@@ -8,7 +8,6 @@ from enforce_typing import enforce_types
 from pdr_backend.lake.csv_data_store import CSVDataStore
 from pdr_backend.lake.lake_mapper import LakeMapper
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
-from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.util.time_types import UnixTimeMs
 
 logger = logging.getLogger("table")
@@ -79,6 +78,7 @@ class NamedTable:
     def __init__(self, table_name: str, table_type: TableType = TableType.NORMAL):
         self.table_name = table_name
         self.table_type = table_type
+        self._dataclass: Union[None, Type["LakeMapper"]] = None
 
     @property
     def fullname(self) -> str:
@@ -91,7 +91,7 @@ class NamedTable:
 
     @property
     def dataclass(self) -> Type[LakeMapper]:
-        if hasattr(self, "_dataclass"):
+        if self._dataclass:
             return self._dataclass
 
         raise AttributeError("dataclass not set")

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -19,7 +19,7 @@ from pdr_backend.lake.prediction import (
 )
 from pdr_backend.lake.slot import Slot, mock_slot, mock_slots
 from pdr_backend.lake.subscription import mock_subscriptions
-from pdr_backend.lake.table import Table
+from pdr_backend.lake.table import NamedTable
 from pdr_backend.lake.test.resources import (
     _gql_data_factory,
     get_filtered_timestamps_df,
@@ -601,16 +601,16 @@ def setup_data(
     )
 
     gql_tables = {
-        "pdr_predictions": Table(Prediction, ppss),
-        "pdr_truevals": Table(Trueval, ppss),
-        "pdr_payouts": Table(Payout, ppss),
-        "pdr_slots": Table(Slot, ppss),
+        "pdr_predictions": NamedTable.from_dataclass(Prediction),
+        "pdr_truevals": NamedTable.from_dataclass(Trueval),
+        "pdr_payouts": NamedTable.from_dataclass(Payout),
+        "pdr_slots": NamedTable.from_dataclass(Slot),
     }
 
-    gql_tables["pdr_predictions"].append_to_storage(preds)
-    gql_tables["pdr_truevals"].append_to_storage(truevals)
-    gql_tables["pdr_payouts"].append_to_storage(payouts)
-    gql_tables["pdr_slots"].append_to_storage(slots)
+    gql_tables["pdr_predictions"].append_to_storage(preds, ppss)
+    gql_tables["pdr_truevals"].append_to_storage(truevals, ppss)
+    gql_tables["pdr_payouts"].append_to_storage(payouts, ppss)
+    gql_tables["pdr_slots"].append_to_storage(slots, ppss)
 
     assert ppss.lake_ss.st_timestamp == UnixTimeMs.from_timestr(st_timestr)
     assert ppss.lake_ss.fin_timestamp == UnixTimeMs.from_timestr(fin_timestr)

--- a/pdr_backend/lake/test/test_etl.py
+++ b/pdr_backend/lake/test/test_etl.py
@@ -403,7 +403,7 @@ def test_calc_bronze_start_end_ts(tmpdir):
     )
 
     gql_data_factory = Mock(spec=gql_data_factory)
-    gql_data_factory.raw_table_names = [
+    mock_gql_tables = [
         "raw_table_1",
         "raw_table_2",
         "raw_table_3",
@@ -417,8 +417,11 @@ def test_calc_bronze_start_end_ts(tmpdir):
     ]
 
     with patch("pdr_backend.lake.etl._ETL_REGISTERED_TABLE_NAMES", mock_tables):
-        # Calculate from + to timestamps
-        from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
+        with patch(
+            "pdr_backend.lake.etl._GQLDF_REGISTERED_TABLE_NAMES", mock_gql_tables
+        ):
+            # Calculate from + to timestamps
+            from_timestamp, to_timestamp = etl._calc_bronze_start_end_ts()
 
     assert (
         UnixTimeMs(from_timestamp).to_dt().strftime("%Y-%m-%d %H:%M:%S")

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -10,7 +10,7 @@ from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.prediction import Prediction, mock_daily_predictions
 from pdr_backend.lake.slot import Slot
 from pdr_backend.lake.subscription import Subscription
-from pdr_backend.lake.table import NamedTable, Table, TempTable
+from pdr_backend.lake.table import NamedTable, TempTable
 from pdr_backend.lake.trueval import Trueval
 from pdr_backend.ppss.ppss import mock_ppss
 from pdr_backend.util.time_types import UnixTimeMs
@@ -168,7 +168,7 @@ def test_calc_start_ut(tmpdir):
     )
 
     gql_data_factory = GQLDataFactory(ppss)
-    table = Table(Prediction, ppss)
+    table = NamedTable.from_dataclass(Prediction)
 
     st_ut = gql_data_factory._calc_start_ut(table)
     assert st_ut.to_seconds() == 1701561601

--- a/pdr_backend/lake/test/test_gql_data_factory.py
+++ b/pdr_backend/lake/test/test_gql_data_factory.py
@@ -153,29 +153,6 @@ def test_update_partial_then_resume(
     ]
 
 
-@patch("pdr_backend.lake.gql_data_factory.GQLDataFactory._update")
-def test_get_gql_tables(mock_update):
-    """
-    Test GQLDataFactory's get_gql_tablesreturns all the tables
-    """
-    mock_update.return_value = None
-    st_timestr = "2023-12-03"
-    fin_timestr = "2024-12-05"
-    ppss = mock_ppss(
-        [{"predict": "binance BTC/USDT c 5m", "train_on": "binance BTC/USDT c 5m"}],
-        "sapphire-mainnet",
-        ".",
-        st_timestr=st_timestr,
-        fin_timestr=fin_timestr,
-    )
-
-    gql_data_factory = GQLDataFactory(ppss)
-
-    gql_dfs = gql_data_factory.get_gql_tables()
-
-    assert len(gql_dfs.items()) == 3
-
-
 def test_calc_start_ut(tmpdir):
     """
     Test GQLDataFactory's calc_start_ut returns the correct UnixTimeMs
@@ -329,7 +306,7 @@ def test_prepare_temp_table_get_data_from_csv_if_production_table_empty(tmpdir):
 
     gql_data_factory = GQLDataFactory(ppss)
 
-    table = Table(Prediction, ppss)
+    table = NamedTable.from_dataclass(Prediction)
     db = DuckDBDataStore(ppss.lake_ss.lake_dir)
 
     initial_response = mock_daily_predictions()
@@ -348,21 +325,17 @@ def test_prepare_temp_table_get_data_from_csv_if_production_table_empty(tmpdir):
         {"contract_list": ["0x123"]},
     )
     assert (
-        len(
-            db.query_data(
-                "SELECT * FROM {}".format("_temp_{}".format(table.table_name))
-            )
-        )
+        len(db.query_data("SELECT * FROM {}".format("_temp_{}".format(table.fullname))))
         == 6
     )
 
     # move temp table to production and check the data is there
-    db.move_table_data(TempTable(table.table_name), table)
+    db.move_table_data(TempTable.from_dataclass(Prediction), table)
 
     # now keep both temp and production tables but remove values
-    db.query_data("DELETE FROM {}".format(table.table_name))
-    db.query_data("DELETE FROM {}".format("_temp_{}".format(table.table_name)))
-    assert len(db.query_data("SELECT * FROM {}".format(table.table_name))) == 0
+    db.query_data("DELETE FROM {}".format(table.fullname))
+    db.query_data("DELETE FROM {}".format("_temp_{}".format(table.fullname)))
+    assert len(db.query_data("SELECT * FROM {}".format(table.fullname))) == 0
 
     # run prepare_temp_table again to check that,
     # if production table doesn't have any rows doesn't break the preparation
@@ -371,6 +344,6 @@ def test_prepare_temp_table_get_data_from_csv_if_production_table_empty(tmpdir):
         UnixTimeMs(1699300800000),
         UnixTimeMs(1699300800000),
     )
-    db.move_table_data(TempTable(table.table_name), table)
+    db.move_table_data(TempTable.from_dataclass(Prediction), table)
 
-    assert len(db.query_data("SELECT * FROM {}".format(table.table_name))) == 6
+    assert len(db.query_data("SELECT * FROM {}".format(table.fullname))) == 6

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -3,7 +3,7 @@ from enforce_typing import enforce_types
 from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
 from pdr_backend.lake.prediction import Prediction
-from pdr_backend.lake.table import NamedTable, Table, TempTable
+from pdr_backend.lake.table import NamedTable, TempTable
 from pdr_backend.lake.table_bronze_pdr_predictions import (
     BronzePrediction,
     get_bronze_pdr_predictions_data_with_SQL,
@@ -32,16 +32,18 @@ def test_table_bronze_pdr_predictions(
     )
 
     gql_tables = {
-        "pdr_predictions": Table(Prediction, ppss),
-        "pdr_truevals": Table(Trueval, ppss),
-        "pdr_payouts": Table(Payout, ppss),
-        "bronze_pdr_predictions": Table(BronzePrediction, ppss),
+        "pdr_predictions": NamedTable.from_dataclass(Prediction),
+        "pdr_truevals": NamedTable.from_dataclass(Trueval),
+        "pdr_payouts": NamedTable.from_dataclass(Payout),
+        "bronze_pdr_predictions": NamedTable.from_dataclass(BronzePrediction),
     }
 
     # Work 1: Append all data onto bronze_table
-    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df)
-    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df)
-    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df)
+    gql_tables["pdr_predictions"].append_to_storage(
+        _gql_datafactory_etl_predictions_df, ppss
+    )
+    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, ppss)
+    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, ppss)
 
     db = DuckDBDataStore(ppss.lake_ss.lake_dir)
     # truevals should have 6

--- a/pdr_backend/lake/test/test_table_bronze_pdr_slots.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_slots.py
@@ -4,7 +4,7 @@ from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
 from pdr_backend.lake.prediction import Prediction
 from pdr_backend.lake.slot import Slot
-from pdr_backend.lake.table import ETLTable, NamedTable, Table, TempTable
+from pdr_backend.lake.table import ETLTable, NamedTable, TempTable
 from pdr_backend.lake.table_bronze_pdr_predictions import (
     BronzePrediction,
     get_bronze_pdr_predictions_data_with_SQL,
@@ -38,19 +38,21 @@ def test_table_bronze_pdr_slots(
     )
 
     gql_tables = {
-        "pdr_predictions": Table(Prediction, ppss),
-        "pdr_truevals": Table(Trueval, ppss),
-        "pdr_payouts": Table(Payout, ppss),
-        "pdr_slots": Table(Slot, ppss),
-        "bronze_pdr_predictions": Table(BronzePrediction, ppss),
-        "bronze_pdr_slots": Table(BronzeSlot, ppss),
+        "pdr_predictions": NamedTable.from_dataclass(Prediction),
+        "pdr_truevals": NamedTable.from_dataclass(Trueval),
+        "pdr_payouts": NamedTable.from_dataclass(Payout),
+        "pdr_slots": NamedTable.from_dataclass(Slot),
+        "bronze_pdr_predictions": NamedTable.from_dataclass(BronzePrediction),
+        "bronze_pdr_slots": NamedTable.from_dataclass(BronzeSlot),
     }
 
     # Work 1: Append all data onto tables
-    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df)
-    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df)
-    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df)
-    gql_tables["pdr_slots"].append_to_storage(_gql_datafactory_etl_slots_df)
+    gql_tables["pdr_predictions"].append_to_storage(
+        _gql_datafactory_etl_predictions_df, ppss
+    )
+    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, ppss)
+    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, ppss)
+    gql_tables["pdr_slots"].append_to_storage(_gql_datafactory_etl_slots_df, ppss)
 
     # Check that the data is appended correctly
     db = DuckDBDataStore(ppss.lake_ss.lake_dir)


### PR DESCRIPTION
Contains #1097, but more radical. This PR also removes Table, which has become redundant. Without a table registry, we have no use with Table objects.

Table = NamedTable that contains type + PPSS configuration

PPSS configuration comes always from the data factory, so we can inject it more freely without creating connective objects such as Table.