### PR TITLE
Issue #1108: Cleanup PPSS handling in ETL

### DIFF
--- a/pdr_backend/analytics/test/test_get_predictions_info.py
+++ b/pdr_backend/analytics/test/test_get_predictions_info.py
@@ -32,7 +32,7 @@ def test_get_predictions_info_main_mainnet(
     )
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -97,7 +97,7 @@ def test_get_predictions_info_bad_date_range(
 
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -152,7 +152,7 @@ def test_get_predictions_info_bad_feed(
 
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     feed_addr = "0x8e0we267779d27c2b3ed5408408ff15d9f3a3152"
 
@@ -195,7 +195,7 @@ def test_get_predictions_info_empty(_gql_datafactory_first_predictions_df, tmpdi
 
     predictions_table = NamedTable.from_dataclass(Prediction)
     predictions_table.append_to_storage(
-        pl.DataFrame([], schema=Prediction.get_lake_schema()), ppss
+        pl.DataFrame([], schema=Prediction.get_lake_schema())
     )
 
     feed_addr = "0x2d8e2267779d27c2b3ed5408408ff15d9f3a3152"

--- a/pdr_backend/analytics/test/test_get_predictoors_info.py
+++ b/pdr_backend/analytics/test/test_get_predictoors_info.py
@@ -29,7 +29,7 @@ def test_get_predictoors_info_main_mainnet(
 
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     user_addr = "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd"
 
@@ -81,7 +81,7 @@ def test_get_predictoors_info_bad_date_range(
 
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     user_addr = "0xaaaa4cb4ff2584bad80ff5f109034a891c3d88dd"
 
@@ -131,7 +131,7 @@ def test_get_predictoors_info_bad_user_address(
 
     predictions_df = _gql_datafactory_first_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     user_addr = "0xbbbb4cb4ff2584bad80ff5f109034a891c3d223"
 

--- a/pdr_backend/analytics/test/test_get_traction_info.py
+++ b/pdr_backend/analytics/test/test_get_traction_info.py
@@ -37,7 +37,7 @@ def test_get_traction_info_main_mainnet(
 
     predictions_df = _gql_datafactory_daily_predictions_df
     predictions_table = NamedTable.from_dataclass(Prediction)
-    predictions_table.append_to_storage(predictions_df, ppss)
+    predictions_table.append_to_storage(predictions_df)
 
     get_traction_info_main(ppss, st_timestr, fin_timestr)
 
@@ -78,7 +78,7 @@ def test_get_traction_info_empty_data(
 
     pdr_prediction_table = NamedTable.from_dataclass(Prediction)
     pdr_prediction_table.append_to_storage(
-        pl.DataFrame([], schema=Prediction.get_lake_schema()), ppss
+        pl.DataFrame([], schema=Prediction.get_lake_schema())
     )
 
     with pytest.raises(AssertionError):

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -97,7 +97,7 @@ class GQLDataFactory:
                 "  Table not yet created. Insert all %s csv data", table.fullname
             )
             data = CSVDataStore.from_table(table, self.ppss).read_all(schema)
-            temp_table._append_to_db(data, self.ppss)
+            temp_table._append_to_db(data)
             return
 
         if db_last_timestamp['max("timestamp")'][0] and (
@@ -109,7 +109,7 @@ class GQLDataFactory:
                 fin_ut,
                 schema,
             )
-            temp_table._append_to_db(data, self.ppss)
+            temp_table._append_to_db(data)
 
     @enforce_types
     def _calc_start_ut(self, table: NamedTable) -> UnixTimeMs:
@@ -206,7 +206,7 @@ class GQLDataFactory:
                 save_backoff_count >= save_backoff_limit or len(df) < pagination_limit
             ) and len(buffer_df) > 0:
                 assert df.schema == dataclass.get_lake_schema()
-                temp_table.append_to_storage(buffer_df, self.ppss)
+                temp_table.append_to_storage(buffer_df)
                 logger.info(
                     "Saved %s records to storage while fetching", len(buffer_df)
                 )
@@ -225,7 +225,7 @@ class GQLDataFactory:
             pagination_offset += pagination_limit
 
         if len(buffer_df) > 0:
-            temp_table.append_to_storage(buffer_df, self.ppss)
+            temp_table.append_to_storage(buffer_df)
             logger.info("Saved %s records to storage while fetching", len(buffer_df))
 
     @enforce_types

--- a/pdr_backend/lake/table.py
+++ b/pdr_backend/lake/table.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from enum import Enum
 from typing import Optional, Type, Union
@@ -6,8 +7,9 @@ import polars as pl
 from enforce_typing import enforce_types
 
 from pdr_backend.lake.csv_data_store import CSVDataStore
-from pdr_backend.lake.lake_mapper import LakeMapper
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
+from pdr_backend.lake.lake_mapper import LakeMapper
+from pdr_backend.ppss.ppss import PPSS
 from pdr_backend.util.time_types import UnixTimeMs
 
 logger = logging.getLogger("table")
@@ -73,12 +75,46 @@ def drop_tables_from_st(db: DuckDBDataStore, type_filter: str, st: UnixTimeMs):
     logger.info("truncated %s rows from %s tables", trunc_count, table_count)
 
 
+def get_caller_ppss():
+    caller_ppss = None
+    prev_frame = inspect.currentframe()
+
+    while caller_ppss is None and prev_frame is not None:
+        prev_frame = prev_frame.f_back
+
+        if not prev_frame:
+            break
+
+        # allow for "magical" ppss retrieval from tests
+        if "test/" in prev_frame.f_code.co_filename:
+            if prev_frame.f_locals.get("etl"):
+                caller_ppss = prev_frame.f_locals["etl"].ppss
+                break
+            if prev_frame.f_locals.get("ppss"):
+                caller_ppss = prev_frame.f_locals["ppss"]
+                break
+
+        # along the way, some caller of the NamedTable.from_dataclass() method
+        # must have a ppss attribute
+        if not prev_frame.f_locals.get("self"):
+            continue
+
+        caller = prev_frame.f_locals["self"]
+        if hasattr(caller, "ppss"):
+            caller_ppss = caller.ppss
+
+    if not caller_ppss:
+        raise ValueError("Could not find a PPSS object in the call stack")
+    return caller_ppss
+
+
 @enforce_types
 class NamedTable:
     def __init__(self, table_name: str, table_type: TableType = TableType.NORMAL):
         self.table_name = table_name
         self.table_type = table_type
         self._dataclass: Union[None, Type["LakeMapper"]] = None
+        self._ppss: Union[None, PPSS] = None
 
     @property
     def fullname(self) -> str:
@@ -96,6 +132,13 @@ class NamedTable:
 
         raise AttributeError("dataclass not set")
 
+    @property
+    def ppss(self) -> PPSS:
+        if self._ppss:
+            return self._ppss
+
+        raise AttributeError("ppss not set")
+
     @staticmethod
     def from_dataclass(
         dataclass: Type[LakeMapper], table_type: Optional[TableType] = None
@@ -105,15 +148,16 @@ class NamedTable:
 
         named_table = NamedTable(dataclass.get_lake_table_name(), table_type)
         named_table._dataclass = dataclass
+        named_table._ppss = get_caller_ppss()
         return named_table
 
     @enforce_types
-    def append_to_storage(self, data: pl.DataFrame, ppss):
-        self._append_to_csv(data, ppss)
-        self._append_to_db(data, ppss)
+    def append_to_storage(self, data: pl.DataFrame):
+        self._append_to_csv(data)
+        self._append_to_db(data)
 
     @enforce_types
-    def _append_to_csv(self, data: pl.DataFrame, ppss):
+    def _append_to_csv(self, data: pl.DataFrame):
         """
         Append the data from the DataFrame object into the CSV file
         It only saves the new data that has been fetched
@@ -121,7 +165,7 @@ class NamedTable:
         @arguments:
             data - The Polars DataFrame to save.
         """
-        csvds = CSVDataStore.from_table(self, ppss)
+        csvds = CSVDataStore.from_table(self, self.ppss)
         logger.info(" csvds = %s", csvds)
         csvds.write(
             data,
@@ -130,7 +174,7 @@ class NamedTable:
         logger.info("  Saved %s rows to csv files: %s", data.shape[0], self.table_name)
 
     @enforce_types
-    def _append_to_db(self, data: pl.DataFrame, ppss):
+    def _append_to_db(self, data: pl.DataFrame):
         """
         Append the data from the DataFrame object into the database
         It only saves the new data that has been fetched
@@ -138,7 +182,7 @@ class NamedTable:
         @arguments:
             data - The Polars DataFrame to save.
         """
-        DuckDBDataStore(ppss.lake_ss.lake_dir).insert_to_table(data, self.fullname)
+        DuckDBDataStore(self.ppss.lake_ss.lake_dir).insert_to_table(data, self.fullname)
         logger.info("  Appended %s rows to db table: %s", data.shape[0], self.fullname)
 
 
@@ -152,6 +196,7 @@ class TempTable(NamedTable):
     def from_dataclass(dataclass: Type[LakeMapper]) -> "TempTable":
         temp_table = TempTable(dataclass.get_lake_table_name())
         temp_table._dataclass = dataclass
+        temp_table._ppss = get_caller_ppss()
         return temp_table
 
 
@@ -165,4 +210,5 @@ class ETLTable(NamedTable):
     def from_dataclass(dataclass: Type[LakeMapper]) -> "ETLTable":
         etl_table = ETLTable(dataclass.get_lake_table_name())
         etl_table._dataclass = dataclass
+        etl_table._ppss = get_caller_ppss()
         return etl_table

--- a/pdr_backend/lake/test/conftest.py
+++ b/pdr_backend/lake/test/conftest.py
@@ -607,10 +607,10 @@ def setup_data(
         "pdr_slots": NamedTable.from_dataclass(Slot),
     }
 
-    gql_tables["pdr_predictions"].append_to_storage(preds, ppss)
-    gql_tables["pdr_truevals"].append_to_storage(truevals, ppss)
-    gql_tables["pdr_payouts"].append_to_storage(payouts, ppss)
-    gql_tables["pdr_slots"].append_to_storage(slots, ppss)
+    gql_tables["pdr_predictions"].append_to_storage(preds)
+    gql_tables["pdr_truevals"].append_to_storage(truevals)
+    gql_tables["pdr_payouts"].append_to_storage(payouts)
+    gql_tables["pdr_slots"].append_to_storage(slots)
 
     assert ppss.lake_ss.st_timestamp == UnixTimeMs.from_timestr(st_timestr)
     assert ppss.lake_ss.fin_timestamp == UnixTimeMs.from_timestr(fin_timestr)

--- a/pdr_backend/lake/test/test_table.py
+++ b/pdr_backend/lake/test/test_table.py
@@ -93,7 +93,7 @@ def test_csv_data_store(
 
     # Initialize Table, fill with data, validate
     table = NamedTable.from_dataclass(Prediction)
-    table._append_to_csv(_gql_datafactory_first_predictions_df, ppss)
+    table._append_to_csv(_gql_datafactory_first_predictions_df)
 
     assert CSVDataStore.from_table(table, ppss).has_data()
 
@@ -111,7 +111,7 @@ def test_csv_data_store(
         file.close()
 
     # Add second batch of predictions, validate
-    table._append_to_csv(_gql_datafactory_1k_predictions_df, ppss)
+    table._append_to_csv(_gql_datafactory_1k_predictions_df)
 
     files = os.listdir(os.path.join(ppss.lake_ss.lake_dir, table.table_name))
     files.sort(reverse=True)
@@ -183,6 +183,9 @@ def test_append_to_db(caplog):
     """
     st_timestr = "2023-12-03"
     fin_timestr = "2023-12-05"
+
+    # ppss automatically retrieved from locals in NamedTable.from_dataclass
+    # pylint: disable=unused-variable
     ppss = mock_ppss(
         [{"predict": "binance BTC/USDT c 5m", "train_on": "binance BTC/USDT c 5m"}],
         "sapphire-mainnet",
@@ -193,6 +196,6 @@ def test_append_to_db(caplog):
 
     table = NamedTable.from_dataclass(Prediction)
     data = pl.DataFrame([mocked_object], Prediction.get_lake_schema())
-    table._append_to_db(data, ppss)
+    table._append_to_db(data)
 
     assert "Appended 1 rows to db table: pdr_predictions" in caplog.text

--- a/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_predictions.py
@@ -1,7 +1,7 @@
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
+from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.prediction import Prediction
 from pdr_backend.lake.table import NamedTable, TempTable
 from pdr_backend.lake.table_bronze_pdr_predictions import (
@@ -39,11 +39,9 @@ def test_table_bronze_pdr_predictions(
     }
 
     # Work 1: Append all data onto bronze_table
-    gql_tables["pdr_predictions"].append_to_storage(
-        _gql_datafactory_etl_predictions_df, ppss
-    )
-    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, ppss)
-    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, ppss)
+    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df)
+    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df)
+    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df)
 
     db = DuckDBDataStore(ppss.lake_ss.lake_dir)
     # truevals should have 6

--- a/pdr_backend/lake/test/test_table_bronze_pdr_slots.py
+++ b/pdr_backend/lake/test/test_table_bronze_pdr_slots.py
@@ -1,7 +1,7 @@
 from enforce_typing import enforce_types
 
-from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
+from pdr_backend.lake.payout import Payout
 from pdr_backend.lake.prediction import Prediction
 from pdr_backend.lake.slot import Slot
 from pdr_backend.lake.table import ETLTable, NamedTable, TempTable
@@ -47,12 +47,10 @@ def test_table_bronze_pdr_slots(
     }
 
     # Work 1: Append all data onto tables
-    gql_tables["pdr_predictions"].append_to_storage(
-        _gql_datafactory_etl_predictions_df, ppss
-    )
-    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df, ppss)
-    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df, ppss)
-    gql_tables["pdr_slots"].append_to_storage(_gql_datafactory_etl_slots_df, ppss)
+    gql_tables["pdr_predictions"].append_to_storage(_gql_datafactory_etl_predictions_df)
+    gql_tables["pdr_truevals"].append_to_storage(_gql_datafactory_etl_truevals_df)
+    gql_tables["pdr_payouts"].append_to_storage(_gql_datafactory_etl_payouts_df)
+    gql_tables["pdr_slots"].append_to_storage(_gql_datafactory_etl_slots_df)
 
     # Check that the data is appended correctly
     db = DuckDBDataStore(ppss.lake_ss.lake_dir)


### PR DESCRIPTION
Closes #1108.

- automatic retrival of the caller ppss. In theory, tables should not be instantiated outside a class that has no ppss. So the solution I proposed is to add frame inspection and loop until we get the caller that has a ppss object. This will usually be GQLDataFactory, but we support any object that has a ppss attribute as a table intantiator.
- the only problem was with tests: in tests, tables are "orphan", so I'm retrieving the ppss object defined in the test `locals`.

I think a similar retrieval can be done on other ppss-dependant objects as well (CSVDataStore, DuckDBDataStore all originate from the same place so they are likely candidates), but here it makes most sense. Let me know if my solution is good to go :)