### PR TITLE
Fix #1135: AttributeError: 'Series' object has no attribute 'has_nulls'

### DIFF
--- a/pdr_backend/util/mathutil.py
+++ b/pdr_backend/util/mathutil.py
@@ -55,11 +55,11 @@ def has_nan(
         return has_None or np.isnan(np.min(x))
 
     if isinstance(x, pl.Series):
-        has_None = x.has_nulls()
+        has_None = x.is_null().any()
         return has_None or sum(x.is_nan()) > 0  # type: ignore[union-attr]
 
     if isinstance(x, pl.DataFrame):
-        has_None = any(col.has_nulls() for col in x)
+        has_None = any(col.is_null().any() for col in x)
         return has_None or sum(sum(x).is_nan()) > 0  # type: ignore[union-attr]
 
     # pd.Series or pd.DataFrame


### PR DESCRIPTION
Full issue name: [mathutil] AttributeError: 'Series' object has no attribute 'has_nulls'. Did you mean: 'is_null'?

Fixes #1135
