### PR TITLE
Fix #1137: ValueError: how must be one of {'inner', ..}, got full

### DIFF
--- a/pdr_backend/lake/merge_df.py
+++ b/pdr_backend/lake/merge_df.py
@@ -73,7 +73,7 @@ def _add_df_col(
     if merged_df is None:
         merged_df = newraw_df
     else:
-        merged_df = merged_df.join(newraw_df, on="timestamp", how="full")
+        merged_df = merged_df.join(newraw_df, on="timestamp", how="outer")
         merged_df = merge_cols(merged_df, "timestamp", "timestamp_right")
 
     # re-order merged_df's columns


### PR DESCRIPTION
Full issue name: [Bug, merge_df] ValueError: how must be one of {'inner', 'left', ..}, got full

Fixes #1137
