### PR TITLE
Fix #1147: Re-order 'Profit' plots to give more space for time dimension

### DIFF
--- a/pdr_backend/sim/dash_plots/view_elements.py
+++ b/pdr_backend/sim/dash_plots/view_elements.py
@@ -77,7 +77,7 @@ def get_tabs(figures):
                         ),
                     ],
                     style={"width": "100%", "height": "100%"},
-                ),  
+                ),
                 html.Div(
                     [
                         dcc.Graph(
@@ -87,7 +87,7 @@ def get_tabs(figures):
                         ),
                     ],
                     style={"width": "50%", "height": "100%"},
-                ),              
+                ),
             ],
         },
         {
@@ -102,7 +102,7 @@ def get_tabs(figures):
                         ),
                     ],
                     style={"width": "100%", "height": "100%"},
-                ),  
+                ),
                 html.Div(
                     [
                         dcc.Graph(
@@ -112,7 +112,7 @@ def get_tabs(figures):
                         ),
                     ],
                     style={"width": "50%", "height": "100%"},
-                ),              
+                ),
             ],
         },
         {

--- a/pdr_backend/sim/dash_plots/view_elements.py
+++ b/pdr_backend/sim/dash_plots/view_elements.py
@@ -3,8 +3,8 @@ from plotly.graph_objs import Figure
 
 figure_names = [
     "pdr_profit_vs_time",
-    "trader_profit_vs_time",
     "pdr_profit_vs_ptrue",
+    "trader_profit_vs_time",
     "trader_profit_vs_ptrue",
     "model_performance_vs_time",
     "aimodel_varimps",
@@ -66,14 +66,53 @@ def side_by_side_graphs(
 def get_tabs(figures):
     return [
         {
-            "name": "Profit",
+            "name": "Predictoor Profit",
             "components": [
-                side_by_side_graphs(
-                    figures, "pdr_profit_vs_time", "trader_profit_vs_time"
-                ),
-                side_by_side_graphs(
-                    figures, "pdr_profit_vs_ptrue", "trader_profit_vs_ptrue"
-                ),
+                html.Div(
+                    [
+                        dcc.Graph(
+                            figure=figures["pdr_profit_vs_time"],
+                            id="pdr_profit_vs_time",
+                            style={"width": "100%", "height": "100%"},
+                        ),
+                    ],
+                    style={"width": "100%", "height": "100%"},
+                ),  
+                html.Div(
+                    [
+                        dcc.Graph(
+                            figure=figures["pdr_profit_vs_ptrue"],
+                            id="pdr_profit_vs_ptrue",
+                            style={"width": "100%", "height": "100%"},
+                        ),
+                    ],
+                    style={"width": "50%", "height": "100%"},
+                ),              
+            ],
+        },
+        {
+            "name": "Trader Profit",
+            "components": [
+                html.Div(
+                    [
+                        dcc.Graph(
+                            figure=figures["trader_profit_vs_time"],
+                            id="trader_profit_vs_time",
+                            style={"width": "100%", "height": "100%"},
+                        ),
+                    ],
+                    style={"width": "100%", "height": "100%"},
+                ),  
+                html.Div(
+                    [
+                        dcc.Graph(
+                            figure=figures["trader_profit_vs_ptrue"],
+                            id="trader_profit_vs_ptrue",
+                            style={"width": "100%", "height": "100%"},
+                        ),
+                    ],
+                    style={"width": "50%", "height": "100%"},
+                ),              
             ],
         },
         {


### PR DESCRIPTION
Fixes #1147