### PR TITLE
Fix #1139 - [test_submit_prediction_and_payout] Increase prediction epoch

### DIFF
--- a/pdr_backend/pred_submitter/test/test_pred_submitter_manager.py
+++ b/pdr_backend/pred_submitter/test/test_pred_submitter_manager.py
@@ -138,7 +138,7 @@ def test_submit_prediction_and_payout(
     current_epoch = feed_contract1.get_current_epoch_ts()
 
     # set prediction epoch
-    prediction_epoch = UnixTimeS(current_epoch + S_PER_EPOCH * 2)
+    prediction_epoch = UnixTimeS(current_epoch + S_PER_EPOCH * 3)
 
     # get the OCEAN balance of the owner before submitting
     bal_before = OCEAN.balanceOf(web3_config.owner)
@@ -170,7 +170,7 @@ def test_submit_prediction_and_payout(
 
     # fast forward time to get payout
     web3_config.w3.provider.make_request(
-        RPCEndpoint("evm_increaseTime"), [S_PER_EPOCH * 4]
+        RPCEndpoint("evm_increaseTime"), [S_PER_EPOCH * 5]
     )
     web3_config.w3.provider.make_request(RPCEndpoint("evm_mine"), [])
 


### PR DESCRIPTION
Fixes #1139

Changes proposed in this PR:

- Increase test epoch number to prevent random failures of the test
