### PR TITLE
Fix #1241: Add import ignore for requests stubs.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -62,6 +62,9 @@ ignore_missing_imports = True
 [mypy-pytest]
 ignore_missing_imports = True
 
+[mypy-requests.*]
+ignore_missing_imports = True
+
 [mypy-sapphirepy.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ install_requirements = [
     "typeguard==4.2.1",
     "types-pytz==2024.1.0.20240417",
     "types-pyYAML==6.0.12.20240311",
-    "types-requests==2.31.0.6",
-    "urllib3<2.0.2",
     "xgboost==2.0.3",
     "dash_bootstrap_components==1.6.0",
     "web3==6.19.0",


### PR DESCRIPTION
Closes #1241.

@trentmc this is the solution that is consistent with our work until now. In mypy.ini, we are ignoring stubs for all other libraries, requests was missing from the list. I suggest we revert the changes you added in setup.py. I can do that if it's fine with you.