### PR TITLE
Fix #1251: [Bug, lake] table_bronze_pdr_slots.py : line-too-long

### DIFF
--- a/pdr_backend/lake/table_bronze_pdr_slots.py
+++ b/pdr_backend/lake/table_bronze_pdr_slots.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 import logging
 from collections import OrderedDict
 from typing import Callable


### PR DESCRIPTION
Fixes #1251
