### PR TITLE
Fix #1269: [Bug, Sim] RegrLinearRidge has wonky prediction errors

### DIFF
--- a/pdr_backend/sim/sim_engine.py
+++ b/pdr_backend/sim/sim_engine.py
@@ -116,6 +116,7 @@ class SimEngine:
     @enforce_types
     def run_one_iter(self, test_i: int, mergedohlcv_df: pl.DataFrame):
         ppss, pdr_ss, st = self.ppss, self.ppss.predictoor_ss, self.st
+        transform = pdr_ss.aimodel_data_ss.transform
         stake_amt = pdr_ss.stake_amount.amt_eth
         others_stake = pdr_ss.others_stake.amt_eth
         revenue = pdr_ss.revenue.amt_eth
@@ -141,7 +142,7 @@ class SimEngine:
         curprice = yraw[-2]
         trueprice = yraw[-1]
 
-        if pdr_ss.aimodel_data_ss.transform == "None":
+        if transform == "None":
             y_thr = curprice
         else:  # transform = "RelDiff"
             y_thr = 0.0
@@ -202,8 +203,12 @@ class SimEngine:
             loss = log_loss(st.ytrues, st.probs_up)
         yerr = 0.0
         if model.do_regr:
-            relchange = model.predict_ycont(X_test)[0]
-            predprice = curprice + relchange * curprice
+            pred_ycont = model.predict_ycont(X_test)[0]
+            if transform == "None":
+                predprice = pred_ycont
+            else:  # transform = "RelDiff"
+                relchange = pred_ycont
+                predprice = curprice + relchange * curprice
             yerr = trueprice - predprice
         st.aim.update(acc_est, acc_l, acc_u, f1, precision, recall, loss, yerr)
 


### PR DESCRIPTION
Fixes #1269

The problem: when `transform=RelDiff` was introduced, the `yerr` calculation was only for `RelDiff`. It neglected to account for `transform=normal` case.
