### PR TITLE
[Fix #1289] Ignore setDaemon deprecation from kaleido/plotly.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,8 @@
 filterwarnings =
     ignore::pytest.PytestUnhandledThreadExceptionWarning
     ignore:.*HTTPResponse.getheader\(\) is deprecated.*
-    ignore:.*This process \(pid=.*\) is multi-threaded, use of fork\(\) may lead to deadlocks in the child.*:DeprecationWarning   
+    ignore:.*setDaemon\(\) is deprecated, set the daemon attribute instead.*:DeprecationWarning
+    ignore:.*This process \(pid=.*\) is multi-threaded, use of fork\(\) may lead to deadlocks in the child.*:DeprecationWarning
 env =
     D:ADDRESS_FILE=~/.ocean/ocean-contracts/artifacts/address.json
     D:RPC_URL=http://127.0.0.1:8545


### PR DESCRIPTION
Closes #1289.