### PR TITLE
Fix #1268: Stop execution if plotting takes too much time.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -86,6 +86,9 @@ ignore_missing_imports = True
 [mypy-solcx.*]
 ignore_missing_imports = True
 
+[mypy-stopit.*]
+ignore_missing_imports = True
+
 [mypy-yaml.*]
 ignore_missing_imports = True
 

--- a/pdr_backend/sim/dash_plots/callbacks.py
+++ b/pdr_backend/sim/dash_plots/callbacks.py
@@ -81,7 +81,9 @@ def get_callbacks(app):
         state_options = sim_plotter.aimodel_plotdata.colnames
         elements.append(selected_var_checklist(state_options, selected_vars_old))
 
-        figures = get_figures_by_state(sim_plotter, selected_vars)
+        timeout = 2 if ts != "final" or n < 2 else 10
+
+        figures = get_figures_by_state(sim_plotter, selected_vars, timeout=timeout)
         tabs = get_tabs(figures)
         selected_tab_value = selected_tab if selected_tab else tabs[0]["name"]
         elements = elements + [get_tabs_component(tabs, selected_tab_value)]

--- a/pdr_backend/sim/dash_plots/util.py
+++ b/pdr_backend/sim/dash_plots/util.py
@@ -2,26 +2,39 @@
 # Copyright 2024 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+import plotly.graph_objects as go
+import stopit
+
 from pdr_backend.aimodel import aimodel_plotter
 from pdr_backend.sim.dash_plots.view_elements import figure_names
 from pdr_backend.sim.sim_plotter import SimPlotter
 
 
-def get_figures_by_state(sim_plotter: SimPlotter, selected_vars):
+def get_figures_by_state(sim_plotter: SimPlotter, selected_vars, timeout=2):
     figures = {}
 
     for key in figure_names:
         if not key.startswith("aimodel"):
-            fig = getattr(sim_plotter, f"plot_{key}")()
-        else:
-            if key in ["aimodel_response", "aimodel_varimps"]:
-                sweep_vars = []
-                for var in selected_vars:
-                    sweep_vars.append(sim_plotter.aimodel_plotdata.colnames.index(var))
-                sim_plotter.aimodel_plotdata.sweep_vars = sweep_vars
+            with stopit.ThreadingTimeout(timeout) as context_manager:
+                fig = getattr(sim_plotter, f"plot_{key}")()
 
-            func_name = getattr(aimodel_plotter, f"plot_{key}")
-            fig = func_name(sim_plotter.aimodel_plotdata)
+            if context_manager.state == context_manager.TIMED_OUT:
+                fig = go.Figure()
+        else:
+            with stopit.ThreadingTimeout(timeout) as context_manager:
+                if key in ["aimodel_response", "aimodel_varimps"]:
+                    sweep_vars = []
+                    for var in selected_vars:
+                        sweep_vars.append(
+                            sim_plotter.aimodel_plotdata.colnames.index(var)
+                        )
+                    sim_plotter.aimodel_plotdata.sweep_vars = sweep_vars
+
+                func_name = getattr(aimodel_plotter, f"plot_{key}")
+                fig = func_name(sim_plotter.aimodel_plotdata)
+
+            if context_manager.state == context_manager.TIMED_OUT:
+                fig = go.Figure()
 
         figures[key] = fig
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requirements = [
     "dash_bootstrap_components==1.6.0",
     "web3==6.20.0",
     "sapphire.py==0.2.3",
+    "stopit==1.1.2",
     "ocean-contracts==2.0.4",  # install this last
 ]
 


### PR DESCRIPTION
Work on #1268. Stops hanging function calls in plotting to enable show of the rest of the dashboard.