### PR TITLE
Revert "Fix #1257: Use chain predictions inside trading sim"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will output something like:
 Usage: pdr sim|predictoor|trader|..
 
 Main tools:
-  pdr sim YAML_FILE NETWORK
+  pdr sim YAML_FILE
   pdr predictoor YAML_FILE NETWORK
   pdr trader APPROACH YAML_FILE NETWORK
 ...

--- a/READMEs/predictoor.md
+++ b/READMEs/predictoor.md
@@ -69,7 +69,7 @@ cp ppss.yaml my_ppss.yaml
 
 Let's run the simulation engine. In console:
 ```console
-pdr sim my_ppss.yaml sapphire-mainnet
+pdr sim my_ppss.yaml
 ```
 
 What the engine does does:

--- a/READMEs/trader.md
+++ b/READMEs/trader.md
@@ -59,21 +59,16 @@ Copy [`ppss.yaml`](../ppss.yaml) into your own file `my_ppss.yaml` and change pa
 cp ppss.yaml my_ppss.yaml
 ```
 
-Chose the source of the predictions used as signals for trading:
-- Own built model, creates predictions on the way   `use_own_model=True`
-- Live chain, gets the predictions from give chain  `use_own_model=False`
-By default `use_own_model` is set to True, and can be changed inside `my_ppss.yaml` file.
-
 Let's run the simulation engine. In console:
 ```console
-pdr sim my_ppss.yaml sapphire-mainnet
+pdr sim my_ppss.yaml
 ```
 
 What the engine does does:
 1. Set simulation parameters.
-2. Grab historical price data from exchanges and stores in `lake_data/` dir. It re-uses any previously saved data.
-3. Run through many 5min epochs. At each epoch:
-   - Build a model or Get predictions from chain
+1. Grab historical price data from exchanges and stores in `lake_data/` dir. It re-uses any previously saved data.
+1. Run through many 5min epochs. At each epoch:
+   - Build a model
    - Predict
    - Trade
    - Log to console and `logs/out_<time>.txt`

--- a/pdr_backend/aimodel/aimodel_plotter.py
+++ b/pdr_backend/aimodel/aimodel_plotter.py
@@ -6,7 +6,6 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from enforce_typing import enforce_types
-from pdr_backend.sim.sim_plotter import empty_fig
 
 from pdr_backend.aimodel.aimodel_plotdata import AimodelPlotdata
 
@@ -343,11 +342,7 @@ def plot_aimodel_varimps(d: AimodelPlotdata):
     @arguments
       d -- AimodelPlotdata
     """
-    try:
-        imps_avg, imps_stddev = d.model.importance_per_var(include_stddev=True)
-    except Exception:
-        return empty_fig("Can't plot var imp for chain data")
-
+    imps_avg, imps_stddev = d.model.importance_per_var(include_stddev=True)
     imps_avg = imps_avg + 1e-15  # give imp > 0, so before dummy vars in plot
     varnames = d.colnames
     n = len(varnames)

--- a/pdr_backend/cli/cli_arguments.py
+++ b/pdr_backend/cli/cli_arguments.py
@@ -23,7 +23,7 @@ Usage: pdr sim|predictoor|trader|..
 
 HELP_MAIN = """
 Main tools:
-  pdr sim PPSS_FILE NETWORK
+  pdr sim PPSS_FILE
   pdr sim_plots [--run_id RUN_ID] [--port PORT] [--debug_mode False]
   pdr predictoor PPSS_FILE NETWORK
   pdr trader APPROACH PPSS_FILE NETWORK
@@ -553,7 +553,7 @@ def print_args(arguments: Namespace, nested_args: dict):
 ## below, list *ArgParser classes in same order as HELP_LONG
 
 # main tools
-SimArgParser = _ArgParser_PPSS_NETWORK
+SimArgParser = _ArgParser_PPSS
 PredictoorArgParser = _ArgParser_PPSS_NETWORK
 TraderArgParser = _ArgParser_APPROACH_PPSS_NETWORK
 ClaimOceanArgParser = _ArgParser_PPSS

--- a/pdr_backend/cli/cli_module.py
+++ b/pdr_backend/cli/cli_module.py
@@ -87,7 +87,7 @@ def _do_main():
 def do_sim(args, nested_args=None):
     ppss = PPSS(
         yaml_filename=args.PPSS_FILE,
-        network=args.NETWORK,
+        network="development",
         nested_override_args=nested_args,
     )
     feedset = ppss.predictoor_ss.predict_train_feedsets[0]

--- a/pdr_backend/cli/test/test_cli_arguments.py
+++ b/pdr_backend/cli/test/test_cli_arguments.py
@@ -37,7 +37,7 @@ def test_do_help_long(capfd):
 def test_print_args(caplog):
     SimArgParser = defined_parsers["do_sim"]
     parser = SimArgParser
-    args = ["sim", "ppss.yaml", "development"]
+    args = ["sim", "ppss.yaml"]
     parsed_args = parser.parse_args(args)
     nested_args = {"foo": "bar"}
 
@@ -46,5 +46,4 @@ def test_print_args(caplog):
     assert "pdr sim: Begin" in caplog.text
     assert "Arguments:" in caplog.text
     assert "PPSS_FILE=ppss.yaml" in caplog.text
-    assert "NETWORK=development" in caplog.text
     assert "foo" in caplog.text

--- a/pdr_backend/cli/test/test_cli_module.py
+++ b/pdr_backend/cli/test/test_cli_module.py
@@ -62,12 +62,12 @@ class _PPSS:
 class _PPSS_OBJ:
     PPSS = PPSSClass(
         yaml_filename=os.path.abspath("ppss.yaml"),
-        network="sapphire-testnet",
+        network="development",
     )
 
 
 class _NETWORK:
-    NETWORK = "sapphire-testnet"
+    NETWORK = "development"
 
 
 class _LOOKBACK:
@@ -233,7 +233,7 @@ def test_do_sim(monkeypatch):
     mock_f = Mock()
     monkeypatch.setattr(f"{_CLI_PATH}.SimEngine.run", mock_f)
 
-    do_sim(MockArgParser_PPSS_NETWORK().parse_args())
+    do_sim(MockArgParser_PPSS().parse_args())
 
     mock_f.assert_called()
 

--- a/pdr_backend/lake/gql_data_factory.py
+++ b/pdr_backend/lake/gql_data_factory.py
@@ -220,8 +220,6 @@ class GQLDataFactory:
                     schema=dataclass.get_lake_schema(),
                 )
                 save_backoff_count = 0
-                if len(df["timestamp"]) == 0:
-                    return
                 if df["timestamp"][0] > df["timestamp"][len(df) - 1]:
                     return
 

--- a/pdr_backend/ppss/ppss.py
+++ b/pdr_backend/ppss/ppss.py
@@ -5,7 +5,6 @@
 import os
 import tempfile
 from typing import Optional, Tuple
-import time
 
 import yaml
 from enforce_typing import enforce_types
@@ -22,7 +21,6 @@ from pdr_backend.ppss.topup_ss import TopupSS
 from pdr_backend.ppss.trader_ss import TraderSS
 from pdr_backend.ppss.trueval_ss import TruevalSS
 from pdr_backend.ppss.exchange_mgr_ss import ExchangeMgrSS
-from pdr_backend.util.time_types import UnixTimeMs, UnixTimeS
 from pdr_backend.ppss.web3_pp import Web3PP
 from pdr_backend.subgraph.subgraph_feed import SubgraphFeed, mock_feed
 from pdr_backend.util.dictutil import recursive_update
@@ -75,7 +73,6 @@ class PPSS:  # pylint: disable=too-many-instance-attributes
 
         # postconditions
         self.verify_feed_dependencies()
-        self.verify_use_chain_data_in_syms_dependencies()
 
     @staticmethod
     def constructor_dict(
@@ -99,27 +96,6 @@ class PPSS:  # pylint: disable=too-many-instance-attributes
             recursive_update(d, nested_override_args)
 
         return d
-
-    def verify_use_chain_data_in_syms_dependencies(self):
-        current_time_s = int(time.time())
-        timeframe = self.trader_ss.feed.timeframe
-        number_of_data_points = self.sim_ss.test_n
-        start_date = current_time_s - (timeframe.s * number_of_data_points)
-        formatted_start_date_as_string = time.strftime(
-            "%Y-%m-%d", time.localtime(start_date)
-        )
-
-        # check if ppss is correctly configured for using chain data into simulations
-        if (
-            UnixTimeS(start_date)
-            < UnixTimeMs.from_timestr(self.lake_ss.st_timestr).to_seconds()
-        ):
-            raise ValueError(
-                (
-                    "Lake dates configuration doesn't meet the requirements. "
-                    f"Make sure you set start date before {formatted_start_date_as_string}"
-                )
-            )
 
     def verify_feed_dependencies(self):
         """Raise ValueError if a feed dependency is violated"""

--- a/pdr_backend/ppss/sim_ss.py
+++ b/pdr_backend/ppss/sim_ss.py
@@ -62,10 +62,6 @@ class SimSS(StrMixin):
     def tradetype(self) -> str:
         return self.d.get("tradetype", "histmock")
 
-    @property
-    def use_own_model(self) -> bool:
-        return self.d["use_own_model"]
-
     # --------------------------------
     # derived methods
     def is_final_iter(self, iter_i: int) -> bool:
@@ -82,13 +78,11 @@ class SimSS(StrMixin):
 @enforce_types
 def sim_ss_test_dict(
     log_dir: str,
-    use_own_model: bool,
     test_n: Optional[int] = None,
     tradetype: Optional[str] = None,
 ) -> dict:
     d = {
         "log_dir": log_dir,
-        "use_own_model": use_own_model,
         "test_n": test_n or 10,
         "tradetype": tradetype or "histmock",
     }

--- a/pdr_backend/ppss/test/test_ppss.py
+++ b/pdr_backend/ppss/test/test_ppss.py
@@ -201,22 +201,3 @@ def test_verify_feed_dependencies():
     ]
     with pytest.raises(ValueError):
         ppss2.verify_feed_dependencies()
-
-
-@enforce_types
-def test_verify_use_chain_data_in_syms_dependencies():
-    # create ppss
-    ppss = mock_ppss(
-        feedset_test_list(),
-        "sapphire-mainnet",
-    )
-
-    # baseline should pass
-    ppss.verify_use_chain_data_in_syms_dependencies()
-
-    # modify lake time and number of epochs to simulate so the verification fails
-    ppss2 = deepcopy(ppss)
-    ppss2.sim_ss.d["test_n"] = 1000
-    ppss2.lake_ss.d["st_timestr"] = "2 hours ago"
-    with pytest.raises(ValueError):
-        ppss2.verify_use_chain_data_in_syms_dependencies()

--- a/pdr_backend/ppss/test/test_sim_ss.py
+++ b/pdr_backend/ppss/test/test_sim_ss.py
@@ -16,7 +16,7 @@ from pdr_backend.ppss.sim_ss import (
 
 @enforce_types
 def test_sim_ss_defaults(tmpdir):
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True)
+    d = sim_ss_test_dict(_logdir(tmpdir))
     ss = SimSS(d)
 
     # yaml properties
@@ -35,7 +35,6 @@ def test_sim_ss_specify_values(tmpdir):
         log_dir=os.path.join(tmpdir, "mylogs"),
         test_n=13,
         tradetype="livereal",
-        use_own_model=True,
     )
     ss = SimSS(d)
 
@@ -53,7 +52,7 @@ def test_sim_ss_log_dir_relative_path():
     # it will work with the relative path
     expanded_path = os.path.abspath("mylogs")
     had_before = os.path.exists(expanded_path)
-    d = sim_ss_test_dict(log_dir="mylogs", use_own_model=True)
+    d = sim_ss_test_dict("mylogs")
     ss = SimSS(d)
     assert ss.log_dir == expanded_path
     if not had_before:
@@ -62,16 +61,16 @@ def test_sim_ss_log_dir_relative_path():
 
 @enforce_types
 def test_sim_ss_test_n_badpaths(tmpdir):
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True, test_n=-3)
+    d = sim_ss_test_dict(_logdir(tmpdir), test_n=-3)
     with pytest.raises(ValueError):
         _ = SimSS(d)
 
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True)
+    d = sim_ss_test_dict(_logdir(tmpdir))
     d["test_n"] = "not_an_int"
     with pytest.raises(TypeError):
         _ = SimSS(d)
 
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True)
+    d = sim_ss_test_dict(_logdir(tmpdir))
     d["test_n"] = 3.2
     with pytest.raises(TypeError):
         _ = SimSS(d)
@@ -80,30 +79,26 @@ def test_sim_ss_test_n_badpaths(tmpdir):
 @enforce_types
 def test_sim_ss_tradetype_happypaths(tmpdir):
     for tradetype in TRADETYPE_OPTIONS:
-        d = sim_ss_test_dict(
-            log_dir=_logdir(tmpdir), use_own_model=True, tradetype=tradetype
-        )
+        d = sim_ss_test_dict(_logdir(tmpdir), tradetype=tradetype)
         ss = SimSS(d)
         assert ss.tradetype == tradetype
 
 
 @enforce_types
 def test_sim_ss_tradetype_badpaths(tmpdir):
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True)
+    d = sim_ss_test_dict(_logdir(tmpdir))
     d["tradetype"] = 3.2
     with pytest.raises(TypeError):
         _ = SimSS(d)
 
-    d = sim_ss_test_dict(
-        log_dir=_logdir(tmpdir), use_own_model=True, tradetype="not a tradetype"
-    )
+    d = sim_ss_test_dict(_logdir(tmpdir), tradetype="not a tradetype")
     with pytest.raises(ValueError):
         _ = SimSS(d)
 
 
 @enforce_types
 def test_sim_ss_is_final_iter(tmpdir):
-    d = sim_ss_test_dict(log_dir=_logdir(tmpdir), use_own_model=True, test_n=10)
+    d = sim_ss_test_dict(_logdir(tmpdir), test_n=10)
     ss = SimSS(d)
     with pytest.raises(ValueError):
         _ = ss.is_final_iter(-5)

--- a/pdr_backend/sim/sim_engine.py
+++ b/pdr_backend/sim/sim_engine.py
@@ -5,8 +5,7 @@
 import logging
 import os
 import uuid
-from typing import Optional, Dict
-import time
+from typing import Optional
 
 import numpy as np
 import polars as pl
@@ -29,8 +28,6 @@ from pdr_backend.sim.sim_trader import SimTrader
 from pdr_backend.sim.sim_state import SimState
 from pdr_backend.util.strutil import shift_one_earlier
 from pdr_backend.util.time_types import UnixTimeMs
-from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
-from pdr_backend.lake.gql_data_factory import GQLDataFactory
 
 logger = logging.getLogger("sim_engine")
 
@@ -65,8 +62,6 @@ class SimEngine:
         else:
             self.multi_id = str(uuid.uuid4())
 
-        self.crt_trained_model: Optional[Aimodel] = None
-        self.prediction_dataset: Optional[Dict[int, float]] = None
         self.model: Optional[Aimodel] = None
 
     @property
@@ -94,21 +89,6 @@ class SimEngine:
         # main loop!
         f = OhlcvDataFactory(self.ppss.lake_ss)
         mergedohlcv_df = f.get_mergedohlcv_df()
-
-        # fetch predictions data
-        if not self.ppss.sim_ss.use_own_model:
-            chain_prediction_data = self._get_past_predictions_from_chain(self.ppss)
-            if not chain_prediction_data:
-                logger.error(
-                    "Could not get the required prediction data to run the simulations"
-                )
-                return
-
-            self.prediction_dataset = self._get_predictions_signals_data(
-                UnixTimeMs(self.ppss.lake_ss.st_timestamp).to_seconds(),
-                UnixTimeMs(self.ppss.lake_ss.fin_timestamp).to_seconds(),
-            )
-
         for test_i in range(self.ppss.sim_ss.test_n):
             self.run_one_iter(test_i, mergedohlcv_df)
 
@@ -124,7 +104,6 @@ class SimEngine:
         revenue = pdr_ss.revenue.amt_eth
 
         testshift = ppss.sim_ss.test_n - test_i - 1  # eg [99, 98, .., 2, 1, 0]
-
         data_f = AimodelDataFactory(pdr_ss)  # type: ignore[arg-type]
         predict_feed = self.predict_train_feedset.predict
         train_feeds = self.predict_train_feedset.train_on
@@ -166,21 +145,9 @@ class SimEngine:
         recent_ut = UnixTimeMs(int(mergedohlcv_df["timestamp"].to_list()[-1]))
         timeframe: ArgTimeframe = predict_feed.timeframe  # type: ignore
         ut = UnixTimeMs(recent_ut - testshift * timeframe.ms)
-        ut_seconds = ut.to_seconds()
 
         # predict price direction
-        if self.ppss.sim_ss.use_own_model:
-            prob_up: float = self.model.predict_ptrue(X_test)[0]  # in [0.0, 1.0]
-        elif (
-            self.prediction_dataset is not None
-            and ut_seconds in self.prediction_dataset
-        ):
-            # check if the current slot is in the keys
-            prob_up = self.prediction_dataset[ut_seconds]
-        else:
-            logger.error("No prediction found at time %s", ut_seconds)
-            return
-
+        prob_up: float = self.model.predict_ptrue(X_test)[0]  # in [0.0, 1.0]
         prob_down: float = 1.0 - prob_up
         conf_up = (prob_up - 0.5) * 2.0  # to range [0,1]
         conf_down = (prob_down - 0.5) * 2.0  # to range [0,1]
@@ -294,95 +261,3 @@ class SimEngine:
             return False, False
 
         return True, False
-
-    @enforce_types
-    def _get_predictions_signals_data(
-        self, start_slot: int, end_slot: int
-    ) -> Dict[int, Optional[float]]:
-        result_dict: Dict[int, Optional[float]] = {}
-        db = DuckDBDataStore(self.ppss.lake_ss.lake_dir)
-        query_cont = f"""
-            SELECT
-                contract
-            FROM
-                pdr_predictions
-            WHERE
-                timeframe = '{self.predict_feed.timeframe}'
-                AND pair = '{self.predict_feed.pair.pair_str}'
-            LIMIT 1
-        """
-        feed_contract_addr = db.query_data(query_cont)
-        if len(feed_contract_addr) == 0:
-            logger.error("Contract address for the given feed not found in database")
-            return result_dict
-
-        query = f"""
-            SELECT
-                slot,
-                CASE
-                    WHEN roundSumStakes = 0.0 THEN NULL
-                    ELSE roundSumStakesUp / roundSumStakes
-                END AS probUp
-            FROM
-                pdr_payouts
-            WHERE
-                slot > {start_slot}
-                AND slot < {end_slot}
-                AND ID LIKE '{feed_contract_addr.row(0)[0]}%'
-        """
-
-        df: pl.DataFrame = db.query_data(query)
-
-        for row in df.to_dicts():
-            if row["probUp"] is not None:
-                result_dict[row["slot"]] = row["probUp"]
-
-        return result_dict
-
-    def _get_past_predictions_from_chain(self, ppss: PPSS):
-        # calculate needed data start date
-        current_time_s = int(time.time())
-        timeframe = ppss.trader_ss.feed.timeframe
-        number_of_data_points = ppss.sim_ss.test_n
-        start_date = current_time_s - (timeframe.s * number_of_data_points)
-
-        # fetch data from subgraph
-        try:
-            gql_data_factory = GQLDataFactory(ppss)
-            gql_data_factory._update()
-        except Exception as e:
-            logger.error("Fetching chain data failed. %s", e)
-
-        # check if required data exists in the data base
-        db = DuckDBDataStore(self.ppss.lake_ss.lake_dir)
-        query = """
-        (SELECT timestamp
-            FROM pdr_payouts
-            ORDER BY timestamp ASC
-            LIMIT 1)
-            UNION ALL
-            (SELECT timestamp
-            FROM pdr_payouts
-            ORDER BY timestamp DESC
-            LIMIT 1);
-        """
-        data: pl.DataFrame = db.query_data(query)
-
-        if data.shape[0] > 0 and len(data["timestamp"]) < 2:
-            logger.info(
-                "No prediction data found in database at %s", self.ppss.lake_ss.lake_dir
-            )
-            return False
-        start_timestamp = UnixTimeMs(data["timestamp"][0]).to_seconds()
-
-        if start_timestamp > start_date:
-            logger.info(
-                (
-                    "Not enough predictions data in the lake. "
-                    "Make sure you fetch data starting from %s up to today"
-                ),
-                time.strftime("%Y-%m-%d", time.localtime(start_date)),
-            )
-            return False
-
-        return True

--- a/pdr_backend/sim/sim_plotter.py
+++ b/pdr_backend/sim/sim_plotter.py
@@ -359,7 +359,7 @@ class SimPlotter:
     @enforce_types
     def plot_prediction_residuals_dist(self):
         if _model_is_classif(self.st):
-            return empty_fig("(Nothing to show because model is a classifier.)")
+            return _empty_fig("(Nothing to show because model is a classifier.)")
 
         # calc data
         d = DistPlotdataFactory.build(self.st.aim.yerrs)
@@ -391,7 +391,7 @@ class SimPlotter:
     @enforce_types
     def plot_prediction_residuals_other(self):
         if _model_is_classif(self.st):
-            return empty_fig()
+            return _empty_fig()
 
         # calc data
         nlags = 10  # magic number alert # FIX ME: have spinner, like ARIMA feeds
@@ -477,7 +477,7 @@ def _model_is_classif(sim_state) -> bool:
 
 
 @enforce_types
-def empty_fig(title=""):
+def _empty_fig(title=""):
     fig = go.Figure()
     w = "white"
     fig.update_layout(title=title, paper_bgcolor=w, plot_bgcolor=w)

--- a/pdr_backend/sim/test/test_multisim_engine.py
+++ b/pdr_backend/sim/test/test_multisim_engine.py
@@ -66,7 +66,7 @@ def _constructor_d_with_fast_runtime(tmpdir):
 
     # sim ss
     log_dir = os.path.join(tmpdir, "logs")
-    sim_d = sim_ss_test_dict(log_dir=log_dir, use_own_model=True, test_n=10)
+    sim_d = sim_ss_test_dict(log_dir=log_dir, test_n=10)
     assert "sim_ss" in main_d
     main_d["sim_ss"] = sim_d
 

--- a/pdr_backend/sim/test/test_sim_engine.py
+++ b/pdr_backend/sim/test/test_sim_engine.py
@@ -3,10 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
-from unittest.mock import patch
 
 import pytest
-import polars as pl
 from dash import Dash
 from enforce_typing import enforce_types
 from selenium.common.exceptions import NoSuchElementException  # type: ignore[import-untyped]
@@ -20,8 +18,6 @@ from pdr_backend.ppss.sim_ss import SimSS, sim_ss_test_dict
 from pdr_backend.sim.dash_plots.callbacks import get_callbacks
 from pdr_backend.sim.dash_plots.view_elements import get_layout
 from pdr_backend.sim.sim_engine import SimEngine
-from pdr_backend.lake.duckdb_data_store import DuckDBDataStore
-from pdr_backend.util.time_types import UnixTimeMs
 
 
 @enforce_types
@@ -61,7 +57,7 @@ def test_sim_engine(tmpdir, check_chromedriver, dash_duo):
 
     # sim ss
     log_dir = os.path.join(tmpdir, "logs")
-    d = sim_ss_test_dict(log_dir, True, test_n=5)
+    d = sim_ss_test_dict(log_dir, test_n=5)
     ppss.sim_ss = SimSS(d)
 
     # go
@@ -108,123 +104,3 @@ def test_sim_engine(tmpdir, check_chromedriver, dash_duo):
         assert "tab--selected" in tab.get_attribute("class")
         for figure_name in figures:
             dash_duo.find_element(f"#{figure_name}")
-
-
-def _clear_test_db(ppss):
-    db = DuckDBDataStore(ppss.lake_ss.lake_dir)
-    db.drop_table("pdr_payouts")
-    db.drop_table("pdr_predictions")
-
-
-def mock_gql_init(self, *args):
-    # assign args.ppss to self.ppss
-    self.ppss = args[0]
-
-    self._update = lambda: mock_gql_update(self)  # Assign the mock update method
-
-
-def mock_gql_update(self):
-    ppss = self.ppss
-
-    db = DuckDBDataStore(ppss.lake_ss.lake_dir)
-    slots = [
-        UnixTimeMs.from_natural_language("1 hour ago").to_seconds(),
-        UnixTimeMs.from_natural_language("55 minutes ago").to_seconds(),
-        UnixTimeMs.from_natural_language("50 minutes ago").to_seconds(),
-        UnixTimeMs.from_natural_language("45 minutes ago").to_seconds(),
-    ]
-
-    contract_address = "0xecefd19314ee798921b053694a23974e406da47b"
-    # payout_ids id = {contract address}-{slot}-{user}
-    payout_ids = [f"{contract_address}-{slot}-0x00" for slot in slots]
-
-    # timestamps are in ms according to slots
-    timestamps = [slot * 1000 for slot in slots]
-
-    db.insert_to_table(
-        pl.DataFrame(
-            {
-                "ID": payout_ids,
-                "slot": slots,
-                "payout": [1, 2, 3, 4],
-                "roundSumStakes": [1, 2, 3, 4],
-                "roundSumStakesUp": [1, 2, 3, 4],
-                "timestamp": timestamps,
-            }
-        ),
-        "pdr_payouts",
-    )
-
-    db.insert_to_table(
-        pl.DataFrame(
-            {
-                "timeframe": ["5m"],
-                "contract": [contract_address],
-                "pair": ["BTC/USDT"],
-            }
-        ),
-        "pdr_predictions",
-    )
-
-
-@enforce_types
-@patch("pdr_backend.sim.sim_engine.GQLDataFactory.__init__", new=mock_gql_init)
-def test_get_predictions_signals_data(tmpdir):
-    s = os.path.abspath("ppss.yaml")
-    d = PPSS.constructor_dict(s)
-
-    d["lake_ss"]["lake_dir"] = os.path.join(tmpdir, "lake_data")
-    d["lake_ss"]["st_timestr"] = "2 hours ago"
-    d["trader_ss"]["feed.timeframe"] = "5m"
-    d["sim_ss"]["test_n"] = 20
-    ppss = PPSS(d=d, network="sapphire-mainnet")
-    feedsets = ppss.predictoor_ss.predict_train_feedsets
-    sim_engine = SimEngine(ppss, feedsets[0])
-
-    # Getting prediction dataset
-    sim_engine._get_past_predictions_from_chain(ppss)
-
-    # check the duckdb file exists in the lake directory
-    assert os.path.exists(ppss.lake_ss.lake_dir)
-    assert os.path.exists(os.path.join(ppss.lake_ss.lake_dir, "duckdb.db"))
-
-    st_ut_s = UnixTimeMs(ppss.lake_ss.st_timestamp).to_seconds()
-    prediction_dataset = sim_engine._get_predictions_signals_data(
-        st_ut_s,
-        UnixTimeMs(ppss.lake_ss.fin_timestamp).to_seconds(),
-    )
-
-    db = DuckDBDataStore(ppss.lake_ss.lake_dir)
-    test_query = f"""
-            SELECT 
-                slot
-            FROM pdr_payouts
-            WHERE
-                slot > {st_ut_s}
-            LIMIT 1"""
-
-    df = db.query_data(test_query)
-    assert df is not None
-    assert isinstance(prediction_dataset, dict)
-
-    assert df["slot"][0] in prediction_dataset
-    _clear_test_db(ppss)
-
-
-@patch("pdr_backend.sim.sim_engine.GQLDataFactory.__init__", new=mock_gql_init)
-def test_get_past_predictions_from_chain():
-    s = os.path.abspath("ppss.yaml")
-    d = PPSS.constructor_dict(s)
-    path = "my_lake_data"
-
-    d["lake_ss"]["lake_dir"] = path
-    d["lake_ss"]["st_timestr"] = "2 hours ago"
-    d["trader_ss"]["feed.timeframe"] = "5m"
-    d["sim_ss"]["test_n"] = 10
-    ppss = PPSS(d=d, network="sapphire-mainnet")
-
-    feedsets = ppss.predictoor_ss.predict_train_feedsets
-    sim_engine = SimEngine(ppss, feedsets[0])
-    resp = sim_engine._get_past_predictions_from_chain(ppss)
-    assert resp is True
-    _clear_test_db(ppss)

--- a/pdr_backend/sim/test/test_sim_logger.py
+++ b/pdr_backend/sim/test/test_sim_logger.py
@@ -17,7 +17,7 @@ def test_compact_num(tmpdir, caplog):
     ppss = PPSS(yaml_str=s, network="development")
 
     log_dir = os.path.join(tmpdir, "logs")
-    d = sim_ss_test_dict(log_dir, use_own_model=True, test_n=5)
+    d = sim_ss_test_dict(log_dir, test_n=5)
     ppss.sim_ss = SimSS(d)
 
     st = Mock(spec=SimState)

--- a/ppss.yaml
+++ b/ppss.yaml
@@ -10,7 +10,7 @@ lake_ss:
     - binance BTC/USDT ETH/USDT 5m
   #    - binance BTC/USDT ETH/USDT BNB/USDT XRP/USDT ADA/USDT DOGE/USDT SOL/USDT LTC/USDT TRX/USDT DOT/USDT 5m
   #    - kraken BTC/USDT 5m
-  st_timestr: 10 days ago # starting date for data
+  st_timestr: 30 days ago # starting date for data
   fin_timestr: now # ending date for data
 
 predictoor_ss:
@@ -68,9 +68,8 @@ trader_ss:
 
 sim_ss: # sim only
   log_dir: logs
-  test_n: 1800 # number of epochs to simulate
+  test_n: 5000 # number of epochs to simulate
   tradetype: histmock # histmock | livemock | livereal
-  use_own_model: True # use own model predictions signals if true, else use chain signals
 
 multisim_ss:
   approach: SimpleSweep # SimpleSweep | FastSweep (future) | ..

--- a/system_tests/test_trader_agent_system.py
+++ b/system_tests/test_trader_agent_system.py
@@ -33,7 +33,6 @@ def setup_mock_objects(mock_web3_pp, mock_feed_contract, feeds):
     mock_trader_ss.min_buffer = 1
     mock_trader_ss.get_feed_from_candidates.return_value = feeds["0x1"]
     mock_trader_ss.exchange_type = "mock"
-    mock_trader_ss.feed.timeframe.s = 300
 
     mock_web3_pp.get_contracts.return_value = {"0x1": mock_feed_contract}
 


### PR DESCRIPTION
Reverts oceanprotocol/pdr-backend#1296

Reverting this, will merge it again after making some changes to reduce complexity down.