### PR TITLE
Follow-up on #1348: Add dependency explanation ref. to stopit decorator.

### DIFF
--- a/READMEs/dependencies.md
+++ b/READMEs/dependencies.md
@@ -67,6 +67,12 @@ If you upgrade selenium or dash[testing], you should check if these warnings are
 
 If you upgrade plotly, you should check if these warnings are still present and remove the ignore statement in `pytest.ini` if they are not.
 
+#### Warnings related to stopit
+- `ignore:.*pkg_resources is deprecated as an API.*:DeprecationWarning` -> due to usage of `stopit`, which is an older library and relies on older versions of `pkg_resources`.
+
+Stopit is a simple wrapper to stop function execution if it takes too long. It is only used in the Sim Plots Dashboard and we should look into removing it.
+If you remove the stopit dependency, you should check if these warnings are still present and remove the ignore statement in `pytest.ini` if they are not.
+
 ## Updating this document
 
 If dependency upgrades fix some issues, or if policies change and this document needs to be updated, please do so.


### PR DESCRIPTION
This issue was already closed by adding the ignore in pytest.ini, but I also added some explanatory test in dependencies.md to cover our bases.

For the record, I also tried to replace `stopit` with something better or create a custom decorator but I only found solutions compatible with Linux and Mac. The sim_plots dashboard would still freeze for windows users. For now, we don't need to replace the `stopit` dependency since it only causes this small warning in the tests, so I didn't insist with my research on execution stoppers.

@trentmc do you think we should delve into this more? I think we can live with this warning for now.