### PR TITLE
[Work on #1402] Allow address config for predictoor dashboard.

### DIFF
--- a/pdr_backend/analytics/predictoor_dashboard/dash_components/view_elements.py
+++ b/pdr_backend/analytics/predictoor_dashboard/dash_components/view_elements.py
@@ -5,6 +5,12 @@ from dash import dcc, html, dash_table
 def get_input_column():
     return html.Div(
         [
+            dcc.Checklist(
+                id="show-favourite-addresses",
+                options=[{"label": "Toggle select my predictors", "value": "true"}],
+                value=[],
+                labelStyle={"display": "inline-block"},
+            ),
             html.Div(
                 get_table(
                     table_id="feeds_table",

--- a/pdr_backend/analytics/predictoor_dashboard/predictoor_dash.py
+++ b/pdr_backend/analytics/predictoor_dashboard/predictoor_dash.py
@@ -25,4 +25,5 @@ def predictoor_dash(ppss: PPSS, debug_mode: bool):
         webbrowser.open(f"http://127.0.0.1:{port}/")
     folder = ppss.lake_ss.lake_dir
     app.layout.children[0].data = folder
+    app.favourite_addresses = ppss.predictoor_ss.my_addresses
     app.run(debug=debug_mode, port=port)

--- a/pdr_backend/analytics/predictoor_dashboard/test/test_callbacks.py
+++ b/pdr_backend/analytics/predictoor_dashboard/test/test_callbacks.py
@@ -51,6 +51,7 @@ def test_get_input_data_from_db(
     app.layout = get_layout()
     get_callbacks(app)
     app.layout.children[0].data = ppss.lake_ss.lake_dir
+    app.favourite_addresses = ppss.predictoor_ss.my_addresses
 
     dash_duo.start_server(app)
     dash_duo.wait_for_element("#feeds_table")

--- a/pdr_backend/ppss/predictoor_ss.py
+++ b/pdr_backend/ppss/predictoor_ss.py
@@ -110,6 +110,10 @@ class PredictoorSS(StrMixin):
     def min_payout_slots(self) -> int:
         return self.d["bot_only"].get("min_payout_slots", 0)
 
+    @property
+    def my_addresses(self) -> List[str]:
+        return self.d.get("my_addresses", [])
+
     # --------------------------------
     # setters (add as needed)
     @enforce_types

--- a/ppss.yaml
+++ b/ppss.yaml
@@ -46,6 +46,8 @@ predictoor_ss:
     train_every_n_epochs: 1
     calc_imps: True
 
+  my_addresses: []
+
 exchange_mgr_ss: # used by trader and sim
   timeout: 30000
   ccxt_params:


### PR DESCRIPTION
Works on #1402. Allows my_addresses configuration, picks up and autoselects those feeds. Should be combined with Norbert's work to trigger feed selection as well.