### PR TITLE
[Work on #1534] Predictoor Dashboard v0.5 - Intermediary work on filters

### DIFF
--- a/pdr_backend/pdr_dashboard/assets/styles.css
+++ b/pdr_backend/pdr_dashboard/assets/styles.css
@@ -190,7 +190,7 @@ button {
     color: black;
 }
 
-#filters-section {
+.filters-section {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
@@ -289,7 +289,7 @@ button {
     height: auto;
 }
 
-#clear_filters_button {
+.clear_filters_button {
     width: "100px";
     padding: 5px;
     border-radius: 5px;

--- a/pdr_backend/pdr_dashboard/callbacks/callbacks_feeds.py
+++ b/pdr_backend/pdr_dashboard/callbacks/callbacks_feeds.py
@@ -23,7 +23,7 @@ def filter_table_by_range(
 
     ctx = callback_context
     button_id = ctx.triggered[0]["prop_id"].split(".")[0]
-    if button_id == "clear_filters_button" or (not min_val and not max_val):
+    if button_id == "clear_feeds_filters_button" or (not min_val and not max_val):
         return label_text
 
     return f"{label_text} {min_val}-{max_val}"
@@ -154,7 +154,7 @@ def get_callbacks_feeds(app):
         State("sales_min", "value"),
         State("sales_max", "value"),
         Input("sales_button", "n_clicks"),
-        Input("clear_filters_button", "n_clicks"),
+        Input("clear_feeds_filters_button", "n_clicks"),
     )
     def filter_table_by_sales_range(
         min_val, max_val, _n_clicks_sales_btn, _n_clicks_filters_bnt
@@ -166,7 +166,7 @@ def get_callbacks_feeds(app):
         State("revenue_min", "value"),
         State("revenue_max", "value"),
         Input("revenue_button", "n_clicks"),
-        Input("clear_filters_button", "n_clicks"),
+        Input("clear_feeds_filters_button", "n_clicks"),
     )
     def filter_table_by_revenue_range(
         min_val, max_val, _n_clicks_revenue_btn, _n_clicks_filters_bnt
@@ -178,7 +178,7 @@ def get_callbacks_feeds(app):
         State("accuracy_min", "value"),
         State("accuracy_max", "value"),
         Input("accuracy_button", "n_clicks"),
-        Input("clear_filters_button", "n_clicks"),
+        Input("clear_feeds_filters_button", "n_clicks"),
     )
     def filter_table_by_accuracy_range(
         min_val, max_val, _n_clicks_accuracy_btn, _n_clicks_filters_bnt
@@ -190,7 +190,7 @@ def get_callbacks_feeds(app):
         State("volume_min", "value"),
         State("volume_max", "value"),
         Input("volume_button", "n_clicks"),
-        Input("clear_filters_button", "n_clicks"),
+        Input("clear_feeds_filters_button", "n_clicks"),
     )
     def filter_table_by_volume_range(
         min_val, max_val, _n_clicks_volume_btn, _n_clicks_filters_bnt
@@ -211,7 +211,7 @@ def get_callbacks_feeds(app):
         Output("volume_min", "value"),
         Output("volume_max", "value"),
         Output("search-input-feeds-table", "value"),
-        Input("clear_filters_button", "n_clicks"),
+        Input("clear_feeds_filters_button", "n_clicks"),
     )
     def clear_all_filters(btn_clicks):
         if not btn_clicks:

--- a/pdr_backend/pdr_dashboard/pages/feeds.py
+++ b/pdr_backend/pdr_dashboard/pages/feeds.py
@@ -80,7 +80,8 @@ class FeedsPage(TabularPage):
                 self.get_filters(),
                 html.Button(
                     "Clear All",
-                    id="clear_filters_button",
+                    id="clear_feeds_filters_button",
+                    className="clear-filters-button",
                     style={
                         "width": "100px",
                         "hight": "100%",
@@ -88,7 +89,8 @@ class FeedsPage(TabularPage):
                     },
                 ),
             ],
-            id="filters-section",
+            className="filters-section",
+            id="feeds-filters-section",
         )
 
     def get_metrics_row(self):

--- a/pdr_backend/pdr_dashboard/pages/predictoors.py
+++ b/pdr_backend/pdr_dashboard/pages/predictoors.py
@@ -15,23 +15,12 @@ from pdr_backend.pdr_dashboard.dash_components.view_elements import (
     get_search_bar,
 )
 from pdr_backend.pdr_dashboard.util.format import format_table
-from pdr_backend.pdr_dashboard.pages.common import TabularPage, Filter, add_to_filter
-
-
-filters = [
-    {"name": "apy", "placeholder": "APY", "options": []},
-    {"name": "accuracy", "placeholder": "Accuracy", "options": []},
-    {"name": "gross_income", "placeholder": "Gross Income", "options": []},
-    {"name": "costs", "placeholder": "Costs", "options": []},
-]
-
-filters_objects = [Filter(**item) for item in filters]
+from pdr_backend.pdr_dashboard.pages.common import TabularPage
 
 
 class PredictoorsPage(TabularPage):
     def __init__(self, app):
         self.app = app
-        # TODO: add_to_filter
 
     def layout(self):
         return html.Div(
@@ -47,12 +36,12 @@ class PredictoorsPage(TabularPage):
     def get_filters(self):
         return html.Div(
             [
-                self.get_multiselect_dropdown(filter_obj)
-                for filter_obj in filters_objects
-            ]
-            + [
+                self.get_input_filter("APY"),
+                self.get_input_filter("Accuracy"),
+                self.get_input_filter("Gross Income"),
                 self.get_input_filter("Nr Feeds"),
                 self.get_input_filter("Stake"),
+                self.get_input_filter("Costs"),
             ],
             className="filters-container",
         )
@@ -63,7 +52,8 @@ class PredictoorsPage(TabularPage):
                 self.get_filters(),
                 html.Button(
                     "Clear All",
-                    id="clear_filters_button",
+                    id="clear_predictoors_filters_button",
+                    className="clear-filters-button",
                     style={
                         "width": "100px",
                         "hight": "100%",
@@ -71,7 +61,8 @@ class PredictoorsPage(TabularPage):
                     },
                 ),
             ],
-            id="filters-section",
+            className="filters-section",
+            id="predictoors-filters-section",
         )
 
     def get_metrics_row(self):
@@ -93,7 +84,7 @@ class PredictoorsPage(TabularPage):
     def get_search_bar_row(self):
         return html.Div(
             children=get_search_bar(
-                "search-input-feeds-table", "Search for predictoors..."
+                "search-input-predictoors-table", "Search for predictoors..."
             ),
             className="search-bar-row",
         )

--- a/pdr_backend/pdr_dashboard/test/resources.py
+++ b/pdr_backend/pdr_dashboard/test/resources.py
@@ -109,8 +109,8 @@ def _remove_tags(text):
     return re.sub(clean, "", text)
 
 
-def _clear_filters(dash_duo):
-    dash_duo.find_element("#clear_filters_button").click()
+def _clear_feeds_filters(dash_duo):
+    dash_duo.find_element("#clear_feeds_filters_button").click()
     time.sleep(1)
 
 

--- a/pdr_backend/pdr_dashboard/test/test_callbacks_feeds.py
+++ b/pdr_backend/pdr_dashboard/test/test_callbacks_feeds.py
@@ -6,7 +6,7 @@ from pdr_backend.pdr_dashboard.test.resources import (
     _navigate_to_feeds_page,
     _assert_table_row_count,
     start_server_and_wait,
-    _clear_filters,
+    _clear_feeds_filters,
     _set_dropdown_and_verify_row_count,
     _set_input_value_and_submit,
     _remove_tags,
@@ -122,7 +122,7 @@ def test_feeds_table_filters(_sample_app, dash_duo):
     _set_dropdown_and_verify_row_count(dash_duo, "#time", "5m", 2)
     _verify_table_data(table, "filtered_base_token_eth_5m.json")
 
-    _clear_filters(dash_duo)
+    _clear_feeds_filters(dash_duo)
     _assert_table_row_count(dash_duo, "#feeds_page_table", 21)
     _verify_table_data(table, "expected_feeds_table_data.json")
 
@@ -130,7 +130,7 @@ def test_feeds_table_filters(_sample_app, dash_duo):
     _set_dropdown_and_verify_row_count(dash_duo, "#base_token", "ADA", 3)
     _verify_table_data(table, "filtered_base_token_ada.json")
 
-    _clear_filters(dash_duo)
+    _clear_feeds_filters(dash_duo)
     # Test filtering with accuracy min value
     _set_input_value_and_submit(
         dash_duo, "#accuracy_dropdown", "#accuracy_min", "90", "#accuracy_button"
@@ -152,7 +152,7 @@ def test_feeds_table_filters(_sample_app, dash_duo):
     _assert_table_row_count(dash_duo, "#feeds_page_table", 1)
     _verify_table_data(table, "filtered_volume_max_1400.json")
 
-    _clear_filters(dash_duo)
+    _clear_feeds_filters(dash_duo)
     _assert_table_row_count(dash_duo, "#feeds_page_table", 21)
     _verify_table_data(table, "expected_feeds_table_data.json")
 


### PR DESCRIPTION
Actual filters depend on tables, currently in work at @kdetry.

This PR does some intermediary work:
- remove option filters, since it seems all filters on the predictoors page are ranged filters
- changes ids for the search button and clear all button to prepare for callback implementations

Work on #1534 will continue once Mustafa's queries are in the codebase